### PR TITLE
[WIP] Add error message for failed ssl connections

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -9,7 +9,9 @@ import logging
 import os.path
 import sys
 import errno
-from urllib.parse import quote, unquote, urljoin
+from urllib.parse import quote, unquote, urljoin, urlparse
+import ssl
+import OpenSSL
 
 import requests
 from bs4 import BeautifulSoup
@@ -110,8 +112,24 @@ class Browser(object):
     def _get(self, url, as_json=False):  # pragma: no cover
         for i in range(1, 7):
             try:
+                # TODO: find a way to supply custom and/or additional certificate stores/chains
+                #r = requests.get(url, auth=self.auth, verify="/usr/share/pki/trust/anchors/SUSE_Trust_Root.crt.pem")
                 r = requests.get(url, auth=self.auth)
-            except requests.exceptions.ConnectionError:
+            except requests.exceptions.SSLError:
+                # as we go one layer deeper from http now, we're just interested in the hostname
+                server_name = urlparse(url).netloc
+                cert = ssl.get_server_certificate((server_name, 443))
+                x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert)
+                issuer_components = x509.get_issuer().get_components()
+                # we're only interested in the b'O'rganizational unit
+                issuers = filter(lambda component: component[0] == b'O', issuer_components)
+                issuer = next(issuers)[1].decode('utf-8', 'ignore')
+                sha1digest = x509.digest('sha1').decode('utf-8', 'ignore')
+                sha256digest = x509.digest('sha256').decode('utf-8', 'ignore')
+                msg = 'Certificate for "%s" from "%s" (sha1: %s, sha256 %s) is not trusted by the system' % (server_name, issuer, sha1digest, sha256digest)
+                log.error(msg)
+                raise DownloadError(msg)
+            except requests.exceptions.ConnectionError as e:
                 log.info("Connection error encountered accessing %s, retrying try %s" % (url, i))
                 continue
             if r.status_code == 502:


### PR DESCRIPTION
This code tries to explain to the user what exactly went wrong if the built-in browser object could not request a URL while generating a report due to an SSL error.

I encountered this on an openQA instance which is only signed by a non-public CA. This certificate could not be validated from requests installed in a virtual environment even though it was valid for the system-wide requests-module.

I'm open for suggestions and opinions (especially on how to handle L#116)

While it requires a lot of parsing, it definitely improves readability for the user and explains what goes wrong. @okurz wdyt?