### PR TITLE
Fix sporadic ASCII encoding errors in python2 on complete report

### DIFF
--- a/bin/openqa-review-daily-email
+++ b/bin/openqa-review-daily-email
@@ -12,12 +12,12 @@ html_target="${html_target:-"/suse/okurz/Export/${html_target_file}"}"
 openqa_review_args="${openqa_review_args:-"--host ${openqa_host} -n -r -T --query-issue-status --no-empty-sections --include-softfails --running-threshold=2 --exclude-job-groups ^(Released|Development|old)"}"
 load_args="${load_args:-"--load --load-dir=${tmp}"}"
 openqa_review_email_args="${openqa_review_email_args:-"${load_args}"}"
-openqa_review_html_args="${openqa_review_html_args:-"${load_args} --report-links"}"
+openqa_review_html_args="${openqa_review_html_args:-"${load_args}"}"
 # this is also putting reminder comments on issues. We can not do this in an
 # explicit later steps as we need all requests to be done when saving the data
 # and if we call it here and also in a later step we would end up with
 # duplicate reminder comments
-openqa_review_save_args="${openqa_review_save_args:-"--report-links --reminder-comment-on-issues --save --save-dir ${tmp}"}"
+openqa_review_save_args="${openqa_review_save_args:-"--reminder-comment-on-issues --save --save-dir ${tmp}"}"
 openqa_review="${openqa_review:-"$(which openqa-review)"}"
 TPL="${TPL:-"$(dirname $0)/../dashboard_files/dashboard.html.in"}"
 # We have to preserve the '$@' until here to prevent too early evaluation of parameters with spaces

--- a/bin/openqa-review-daily-email
+++ b/bin/openqa-review-daily-email
@@ -1,7 +1,9 @@
 #!/bin/sh -e
 
 . $(dirname $0)/_common
-setup_tmpdir
+if [ -z ${tmp+x} ]; then
+    setup_tmpdir
+fi
 
 openqa_host="${openqa_host:-"https://openqa.suse.de"}"
 recv="${recv:-"openqa-suse-status@suse.de"}"

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -1261,7 +1261,8 @@ def main():  # pragma: no cover, only interactive
             print("Available filters: %s" % ', '.join(ie_filters.keys()))
             sys.exit(1)
 
-    print(str(report))
+    report_str = str(report)
+    print(report_str.encode('utf-8'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It is hard to fix these errors on python2 and we thought we caught them all
already in before. Hopefully this helps again. I am not really sure because I
could only reproduce the problem based on the complete report generation from
https://openqa.suse.de not relying on any locally saved files. Probably the
content is still encoded differently when read remotely or from files. Each
run took to check takes 40-50 minutes so it was a lengthly fixing process :)