### PR TITLE
Generate report including the skipped test

### DIFF
--- a/tests/report25_T.md
+++ b/tests/report25_T.md
@@ -13,6 +13,11 @@
 **Arch:** x86_64
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+
+
+
 **New Product bugs:**
 
 * soft fails: [upgrade_offline_13.1_allpatterns](https://openqa.opensuse.org/tests/169809)

--- a/tests/report25_TT.md
+++ b/tests/report25_TT.md
@@ -13,6 +13,11 @@
 **Arch:** x86_64
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+
+
+
 **New Product bugs:**
 
 * soft fails: [upgrade_offline_13.1_allpatterns](https://openqa.opensuse.org/tests/169809) [(ref)](https://openqa.opensuse.org/tests/169614 "Previous test")

--- a/tests/report25_TTT.md
+++ b/tests/report25_TTT.md
@@ -20,6 +20,11 @@
 **Arch:** x86_64
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+
+
+
 **New Product bugs:**
 
 * soft fails: [upgrade_offline_13.1_allpatterns](https://openqa.opensuse.org/tests/169809) [(ref)](https://openqa.opensuse.org/tests/169614 "Previous test")

--- a/tests/report25_terse.md
+++ b/tests/report25_terse.md
@@ -13,6 +13,11 @@
 **Arch:** x86_64
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+
+
+
 **New Product bugs:**
 
 * soft fails: upgrade_offline_13.1_allpatterns

--- a/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1500%26groupid%3D25
+++ b/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1500%26groupid%3D25
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-      <!-- Meta, title, CSS, favicons, etc. -->
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta name="description" content="openQA is a testing framework mainly for distributions">
-      <meta name="keywords" content="Testing, Linux, Qemu">
-      <meta name="author" content="openQA contributors">
+        <!-- Meta, title, CSS, favicons, etc. -->
+	      <meta charset="utf-8">
+	            <meta http-equiv="X-UA-Compatible" content="IE=edge">
+		          <meta name="viewport" content="width=device-width, initial-scale=1">
+			        <meta name="description" content="openQA is a testing framework mainly for distributions">
+				      <meta name="keywords" content="Testing, Linux, Qemu">
+				            <meta name="author" content="openQA contributors">
 
       <meta name="csrf-token" content="c83ee0e35d3c906e5b0d02f1828a21e86a0f5894" />
-      <meta name="csrf-param" content="csrf_token" />
+            <meta name="csrf-param" content="csrf_token" />
 
       <title>openQA: Test summary</title>
 
       <!-- Bootstrap core CSS -->
-      <link href="/packed/bootstrap-fa602e94cf94f5a7381026cbf851235c.min.css" rel="stylesheet">
-      <script src="/packed/bootstrap-a16e5e5a773802743036fa84c021314a.min.js"></script>
+            <link href="/packed/bootstrap-fa602e94cf94f5a7381026cbf851235c.min.css" rel="stylesheet">
+	          <script src="/packed/bootstrap-a16e5e5a773802743036fa84c021314a.min.js"></script>
 
 
 
@@ -24,7 +24,7 @@
 
 
       $(document).ready(function() {
-          setupOverview();
+                setupOverview();
 
       } );
 
@@ -32,81 +32,81 @@
       <link rel="icon" href="/favicon.ico">
 
   </head>
-  <body>
-    <div id="wrapper">
-      <nav class='container-fluid navbar navbar-default navbar-static-top'>
-<div class='navbar-inner'>
-    <div class='container'>
-    <div class="navbar-header">
-        <a class="navbar-brand" href="#">
-        <img alt="Brand" src="/images/header-logo.png" />
-        </a>
-    </div>
-    <div class='collapse navbar-collapse'>
-        <ul class='nav navbar-nav' id='global-navigation'>
-        <li id='item-downloads'><a href="http://en.opensuse.org/openSUSE:Browse#Downloads">Downloads</a></li>
-        <li id='item-support'><a href="http://en.opensuse.org/openSUSE:Browse#Support">Support</a></li>
-        <li id='item-community'><a href="http://en.opensuse.org/openSUSE:Browse#Community">Community</a></li>
-        <li id='item-development'><a href="http://en.opensuse.org/openSUSE:Browse#Development">Development</a></li>
-        </ul>
-    </div>
-    </div>
-</div>
-</nav>
+    <body>
+        <div id="wrapper">
+	      <nav class='container-fluid navbar navbar-default navbar-static-top'>
+	      <div class='navbar-inner'>
+	          <div class='container'>
+		      <div class="navbar-header">
+		              <a class="navbar-brand" href="#">
+			              <img alt="Brand" src="/images/header-logo.png" />
+				              </a>
+					          </div>
+						      <div class='collapse navbar-collapse'>
+						              <ul class='nav navbar-nav' id='global-navigation'>
+							              <li id='item-downloads'><a href="http://en.opensuse.org/openSUSE:Browse#Downloads">Downloads</a></li>
+								              <li id='item-support'><a href="http://en.opensuse.org/openSUSE:Browse#Support">Support</a></li>
+									              <li id='item-community'><a href="http://en.opensuse.org/openSUSE:Browse#Community">Community</a></li>
+										              <li id='item-development'><a href="http://en.opensuse.org/openSUSE:Browse#Development">Development</a></li>
+											              </ul>
+												          </div>
+													      </div>
+													      </div>
+													      </nav>
 
       <div class='container'>
-      <div class='row' id='subheader'>
-          <div class='col-md-7'>
-          <div id="breadcrump" class="breadcrumb grid_10 alpha"><a href="/"><img alt="Home" src="/images/home_grey.png"><b>openQA</b></a> > <a href="/tests">Test results</a> > Build overview</div>
-          </div>
-          <div class='col-md-5 text-right'>
-          <div id="user-info">
-              <a href="/login">Login</a>
-          </div>
-          </div>
-      </div>
+            <div class='row' id='subheader'>
+	              <div class='col-md-7'>
+		                <div id="breadcrump" class="breadcrumb grid_10 alpha"><a href="/"><img alt="Home" src="/images/home_grey.png"><b>openQA</b></a> > <a href="/tests">Test results</a> > Build overview</div>
+				          </div>
+					            <div class='col-md-5 text-right'>
+						              <div id="user-info">
+							                    <a href="/login">Login</a>
+									              </div>
+										                </div>
+												      </div>
 
 
 <div class="container">
     <h2>Test result overview</h2>
-    <div id="summary" class="panel panel-danger">
-        <div class="panel-heading">
-            Overall Summary of
-                <b><a href="/group_overview/25">Acceptance: openSUSE Tumbleweed  1.Gnome</a></b>
-            build 1500
-        </div>
-        <div class="panel-body">
-            Passed: <span class="badge">30</span>
+        <div id="summary" class="panel panel-danger">
+	        <div class="panel-heading">
+		            Overall Summary of
+			                    <b><a href="/group_overview/25">Acceptance: openSUSE Tumbleweed  1.Gnome</a></b>
+					                build 1500
+							        </div>
+								        <div class="panel-body">
+									            Passed: <span class="badge">30</span>
 
                 Soft Failure:
-                <span class="badge">75</span>
-            Failed: <span class="badge">31</span>
+		                <span class="badge">75</span>
+				            Failed: <span class="badge">31</span>
 
                 None:
-                <span class="badge">5</span>
-        </div>
-    </div>
-        <h3>Flavor: Gnome-DVD</h3>
-        <table id="results_Gnome-DVD" class="overview table table-striped table-hover">
-            <thead>
-                <tr id="flavors">
-                    <th>Test</th>
-                        <th id="flavor_Gnome-DVD_arch_arm">arm</th>
-                        <th id="flavor_Gnome-DVD_arch_i586">i586</th>
-                        <th id="flavor_Gnome-DVD_arch_x86_64">x86_64</th>
-                </tr>
-            </thead>
-            <tbody>
-                    <tr>
-                        <td class="name">RAID0</td>
+		                <span class="badge">5</span>
+				        </div>
+					    </div>
+					            <h3>Flavor: Gnome-DVD</h3>
+						            <table id="results_Gnome-DVD" class="overview table table-striped table-hover">
+							                <thead>
+									                <tr id="flavors">
+											                    <th>Test</th>
+													                            <th id="flavor_Gnome-DVD_arch_arm">arm</th>
+																                            <th id="flavor_Gnome-DVD_arch_i586">i586</th>
+																			                            <th id="flavor_Gnome-DVD_arch_x86_64">x86_64</th>
+																						                    </tr>
+																								                </thead>
+																										            <tbody>
+																											                        <tr>
+																														                        <td class="name">RAID0</td>
 
                             <td id="res_Gnome-DVD_arm_RAID0">
 
              <span id="res-382476">
-                 <a href="/tests/382476">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382476">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -118,26 +118,26 @@
                             <td id="res_Gnome-DVD_x86_64_RAID0">
 
              <span id="res-382626">
-                 <a href="/tests/382626">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382626">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">RAID1</td>
+		                        <tr>
+					                        <td class="name">RAID1</td>
 
                             <td id="res_Gnome-DVD_arm_RAID1">
 
              <span id="res-382477">
-                 <a href="/tests/382477">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382477">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -149,26 +149,26 @@
                             <td id="res_Gnome-DVD_x86_64_RAID1">
 
              <span id="res-382627">
-                 <a href="/tests/382627">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382627">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">RAID10</td>
+		                        <tr>
+					                        <td class="name">RAID10</td>
 
                             <td id="res_Gnome-DVD_arm_RAID10">
 
              <span id="res-382478">
-                 <a href="/tests/382478">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382478">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -180,26 +180,26 @@
                             <td id="res_Gnome-DVD_x86_64_RAID10">
 
              <span id="res-382512">
-                 <a href="/tests/382512">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382512">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">RAID5</td>
+		                        <tr>
+					                        <td class="name">RAID5</td>
 
                             <td id="res_Gnome-DVD_arm_RAID5">
 
              <span id="res-382444">
-                 <a href="/tests/382444">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382444">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -211,26 +211,26 @@
                             <td id="res_Gnome-DVD_x86_64_RAID5">
 
              <span id="res-382513">
-                 <a href="/tests/382513">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382513">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">RAID6</td>
+		                        <tr>
+					                        <td class="name">RAID6</td>
 
                             <td id="res_Gnome-DVD_arm_RAID6">
 
              <span id="res-382443">
-                 <a href="/tests/382443">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382443">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -242,18 +242,18 @@
                             <td id="res_Gnome-DVD_x86_64_RAID6">
 
              <span id="res-382528">
-                 <a href="/tests/382528">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382528">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">USBinstall</td>
+		                        <tr>
+					                        <td class="name">USBinstall</td>
 
                                 <td>-</td>
 
@@ -262,18 +262,18 @@
                             <td id="res_Gnome-DVD_x86_64_USBinstall">
 
              <span id="res-382529">
-                 <a href="/tests/382529">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382529">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">USBinstall@uefi</td>
+		                        <tr>
+					                        <td class="name">USBinstall@uefi</td>
 
                                 <td>-</td>
 
@@ -282,33 +282,33 @@
                             <td id="res_Gnome-DVD_x86_64_USBinstall@uefi">
 
              <span id="res-382530">
-                 <a href="/tests/382530">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382530">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">allpatterns</td>
+		                        <tr>
+					                        <td class="name">allpatterns</td>
 
                             <td id="res_Gnome-DVD_arm_allpatterns">
 
              <span id="res-382452">
-                 <a href="/tests/382452">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382452">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382452/modules/yast2_bootloader/steps/6">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382452/modules/yast2_bootloader/steps/6">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -317,23 +317,23 @@
                             <td id="res_Gnome-DVD_i586_allpatterns">
 
              <span id="res-382498">
-                 <a href="/tests/382498">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382498">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>desktop-runner-20140523</li><li>desktop-runner-20150730</li><li>desktop-runner-20160502</li><li>desktop-runner-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382498/modules/xterm/steps/7">
-            xterm
-        </a>
-    </span>
+            <a href="/tests/382498/modules/xterm/steps/7">
+	                xterm
+			        </a>
+				    </span>
 
              <span id="bug-382498">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -341,28 +341,28 @@
                             <td id="res_Gnome-DVD_x86_64_allpatterns">
 
              <span id="res-382531">
-                 <a href="/tests/382531">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382531">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="allpatterns@i586--l2">allpatterns@i586--vswi ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="allpatterns@i586--l2">allpatterns@i586--vswi ...</span></td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_allpatterns@i586--l2">
 
              <span id="res-382500">
-                 <a href="/tests/382500">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382500">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -370,9 +370,9 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">autoupgrade_13.1</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">autoupgrade_13.1</td>
 
                                 <td>-</td>
 
@@ -381,33 +381,33 @@
                             <td id="res_Gnome-DVD_x86_64_autoupgrade_13.1">
 
              <span id="res-382532">
-                 <a href="/tests/382532">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382532">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>text-login-20140219</li><li>text-login-20160416</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382532/modules/console/steps/6">
-            console
-        </a>
-    </span>
+            <a href="/tests/382532/modules/console/steps/6">
+	                console
+			        </a>
+				    </span>
 
     <span  class="failedmodule" >
-        <a href="/tests/382532/modules/installation/steps/1">
-            installation
-        </a>
-    </span>
+            <a href="/tests/382532/modules/installation/steps/1">
+	                installation
+			        </a>
+				    </span>
 
              <span id="test-label-382532">
-        <i class="test-label label_dependency_issue fa fa-bookmark" title="dependency_issue"></i>
-    </span>
+	             <i class="test-label label_dependency_issue fa fa-bookmark" title="dependency_issue"></i>
+		         </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">autoupgrade_13.2_ga</td>
+		                        <tr>
+					                        <td class="name">autoupgrade_13.2_ga</td>
 
                                 <td>-</td>
 
@@ -416,18 +416,18 @@
                             <td id="res_Gnome-DVD_x86_64_autoupgrade_13.2_ga">
 
              <span id="res-382603">
-                 <a href="/tests/382603">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382603">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">autoupgrade_13.2</td>
+		                        <tr>
+					                        <td class="name">autoupgrade_13.2</td>
 
                                 <td>-</td>
 
@@ -436,18 +436,18 @@
                             <td id="res_Gnome-DVD_x86_64_autoupgrade_13.2">
 
              <span id="res-382604">
-                 <a href="/tests/382604">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382604">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">autoyast_13.2_ext4</td>
+		                        <tr>
+					                        <td class="name">autoyast_13.2_ext4</td>
 
                                 <td>-</td>
 
@@ -456,18 +456,18 @@
                             <td id="res_Gnome-DVD_x86_64_autoyast_13.2_ext4">
 
              <span id="res-382533">
-                 <a href="/tests/382533">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382533">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">autoyast_13.2_gnome</td>
+		                        <tr>
+					                        <td class="name">autoyast_13.2_gnome</td>
 
                                 <td>-</td>
 
@@ -476,37 +476,37 @@
                             <td id="res_Gnome-DVD_x86_64_autoyast_13.2_gnome">
 
              <span id="res-382534">
-                 <a href="/tests/382534">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382534">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">boot_to_snapshot</td>
+		                        <tr>
+					                        <td class="name">boot_to_snapshot</td>
 
                             <td id="res_Gnome-DVD_arm_boot_to_snapshot">
 
              <span id="res-382453">
-                 <a href="/tests/382453">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382453">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>autoyast-system-login-console-20150529</li><li>autoyast-system-login-console-minimal-20160113</li><li>linux-login-20150120</li><li>linux-login-20150922</li><li>tty2-selected-20151201</li><li>tty2-selected-20160508</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382453/modules/boot_into_snapshot/steps/3">
-            boot_into_snapshot
-        </a>
-    </span>
+            <a href="/tests/382453/modules/boot_into_snapshot/steps/3">
+	                boot_into_snapshot
+			        </a>
+				    </span>
 
              <span id="test-label-382453">
-        <i class="test-label label_race_cond fa fa-bookmark" title="race_cond"></i>
-    </span>
+	             <i class="test-label label_race_cond fa fa-bookmark" title="race_cond"></i>
+		         </span>
 
 </td>
 
@@ -516,26 +516,26 @@
                             <td id="res_Gnome-DVD_x86_64_boot_to_snapshot">
 
              <span id="res-382535">
-                 <a href="/tests/382535">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382535">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">btrfs</td>
+		                        <tr>
+					                        <td class="name">btrfs</td>
 
                             <td id="res_Gnome-DVD_arm_btrfs">
 
              <span id="res-382454">
-                 <a href="/tests/382454">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382454">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -545,10 +545,10 @@
                             <td id="res_Gnome-DVD_i586_btrfs">
 
              <span id="res-382495">
-                 <a href="/tests/382495">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382495">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -558,28 +558,28 @@
                             <td id="res_Gnome-DVD_x86_64_btrfs">
 
              <span id="res-382536">
-                 <a href="/tests/382536">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382536">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l2</td>
+		                        <tr>
+					                        <td class="name">btrfs@i586--l2</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_btrfs@i586--l2">
 
              <span id="res-382784">
-                 <a href="/tests/382784">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382784">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -587,19 +587,19 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l3</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">btrfs@i586--l3</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_btrfs@i586--l3">
 
              <span id="res-382503">
-                 <a href="/tests/382503">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382503">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -607,19 +607,19 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l2</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">btrfs@i586--l2</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_btrfs@i586--l2">
 
              <span id="res-382504">
-                 <a href="/tests/382504">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382504">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -627,19 +627,19 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l3</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">btrfs@i586--l3</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_btrfs@i586--l3">
 
              <span id="res-382496">
-                 <a href="/tests/382496">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382496">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -647,30 +647,30 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">cryptlvm</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">cryptlvm</td>
 
                             <td id="res_Gnome-DVD_arm_cryptlvm">
 
              <span id="res-382455">
-                 <a href="/tests/382455">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382455">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>rebootnow-20131217</li><li>rebootnow-20150409</li><li>rebootnow-20160430</li><li>rebootnow-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382455/modules/install_and_reboot/steps/21">
-            install_and_reboot
-        </a>
-    </span>
+            <a href="/tests/382455/modules/install_and_reboot/steps/21">
+	                install_and_reboot
+			        </a>
+				    </span>
 
              <span id="bug-382455">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -680,39 +680,39 @@
                             <td id="res_Gnome-DVD_x86_64_cryptlvm">
 
              <span id="res-382537">
-                 <a href="/tests/382537">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382537">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">cryptlvm_minimal_x</td>
+		                        <tr>
+					                        <td class="name">cryptlvm_minimal_x</td>
 
                             <td id="res_Gnome-DVD_arm_cryptlvm_minimal_x">
 
              <span id="res-382456">
-                 <a href="/tests/382456">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382456">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>rebootnow-20131217</li><li>rebootnow-20150409</li><li>rebootnow-20160430</li><li>rebootnow-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382456/modules/install_and_reboot/steps/21">
-            install_and_reboot
-        </a>
-    </span>
+            <a href="/tests/382456/modules/install_and_reboot/steps/21">
+	                install_and_reboot
+			        </a>
+				    </span>
 
              <span id="bug-382456">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -722,26 +722,26 @@
                             <td id="res_Gnome-DVD_x86_64_cryptlvm_minimal_x">
 
              <span id="res-382538">
-                 <a href="/tests/382538">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382538">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">ext4</td>
+		                        <tr>
+					                        <td class="name">ext4</td>
 
                             <td id="res_Gnome-DVD_arm_ext4">
 
              <span id="res-382457">
-                 <a href="/tests/382457">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382457">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -751,10 +751,10 @@
                             <td id="res_Gnome-DVD_i586_ext4">
 
              <span id="res-382505">
-                 <a href="/tests/382505">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382505">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -764,64 +764,64 @@
                             <td id="res_Gnome-DVD_x86_64_ext4">
 
              <span id="res-382571">
-                 <a href="/tests/382571">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382571">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">ext4@i586--l2</td>
+		                        <tr>
+					                        <td class="name">ext4@i586--l2</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_ext4@i586--l2">
 
              <span id="res-382497">
-                 <a href="/tests/382497">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382497">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>rebootnow-20131217</li><li>rebootnow-20150409</li><li>rebootnow-20160430</li><li>rebootnow-20160504</li><li>rebootnow-390x-20150709</li><li>rebootnow-390x-20160225</li><li>rebootnow-390x-20160502</li><li>rebootnow-390x-20160506</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382497/modules/install_and_reboot/steps/3">
-            install_and_reboot
-        </a>
-    </span>
+            <a href="/tests/382497/modules/install_and_reboot/steps/3">
+	                install_and_reboot
+			        </a>
+				    </span>
 
              <span id="bug-382497">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gnome</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">gnome</td>
 
                             <td id="res_Gnome-DVD_arm_gnome">
 
              <span id="res-382458">
-                 <a href="/tests/382458">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382458">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382458/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382458/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -830,23 +830,23 @@
                             <td id="res_Gnome-DVD_i586_gnome">
 
              <span id="res-382509">
-                 <a href="/tests/382509">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382509">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>desktop-runner-20140523</li><li>desktop-runner-20150730</li><li>desktop-runner-20160502</li><li>desktop-runner-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382509/modules/xterm/steps/7">
-            xterm
-        </a>
-    </span>
+            <a href="/tests/382509/modules/xterm/steps/7">
+	                xterm
+			        </a>
+				    </span>
 
              <span id="bug-382509">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -854,18 +854,18 @@
                             <td id="res_Gnome-DVD_x86_64_gnome">
 
              <span id="res-382572">
-                 <a href="/tests/382572">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382572">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">gnome@64bit-ipmi</td>
+		                        <tr>
+					                        <td class="name">gnome@64bit-ipmi</td>
 
                                 <td>-</td>
 
@@ -874,14 +874,14 @@
                             <td id="res_Gnome-DVD_x86_64_gnome@64bit-ipmi">
 
              <a href="/tests/382612">
-                 <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
-             </a>
+	                      <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
+			                   </a>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">gnome@64bit-smp</td>
+		                        <tr>
+					                        <td class="name">gnome@64bit-smp</td>
 
                                 <td>-</td>
 
@@ -890,45 +890,45 @@
                             <td id="res_Gnome-DVD_x86_64_gnome@64bit-smp">
 
              <span id="res-382573">
-                 <a href="/tests/382573">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382573">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>shutdown-gnome-20140605</li><li>shutdown-gnome-20160502</li><li>shutdown-gnome-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382573/modules/reboot_gnome/steps/2">
-            reboot_gnome
-        </a>
-    </span>
-         +1
+            <a href="/tests/382573/modules/reboot_gnome/steps/2">
+	                reboot_gnome
+			        </a>
+				    </span>
+				             +1
 
              <span id="bug-382573">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">gnome@arm-smp</td>
+		                        <tr>
+					                        <td class="name">gnome@arm-smp</td>
 
                             <td id="res_Gnome-DVD_arm_gnome@arm-smp">
 
              <span id="res-382460">
-                 <a href="/tests/382460">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382460">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382460/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382460/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -937,19 +937,19 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gnome@i586--l2</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">gnome@i586--l2</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_gnome@i586--l2">
 
              <span id="res-382491">
-                 <a href="/tests/382491">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382491">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -957,9 +957,9 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gnome@uefi</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">gnome@uefi</td>
 
                                 <td>-</td>
 
@@ -968,37 +968,37 @@
                             <td id="res_Gnome-DVD_x86_64_gnome@uefi">
 
              <span id="res-382574">
-                 <a href="/tests/382574">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382574">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>license-not-accepted-20160420</li><li>license-not-accepted-20160429</li><li>license-not-accepted-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382574/modules/welcome/steps/4">
-            welcome
-        </a>
-    </span>
+            <a href="/tests/382574/modules/welcome/steps/4">
+	                welcome
+			        </a>
+				    </span>
 
              <span id="bug-382574">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">gpt</td>
+		                        <tr>
+					                        <td class="name">gpt</td>
 
                             <td id="res_Gnome-DVD_arm_gpt">
 
              <span id="res-382459">
-                 <a href="/tests/382459">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382459">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -1008,28 +1008,28 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">installcheck</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">installcheck</td>
 
                             <td id="res_Gnome-DVD_arm_installcheck">
 
              <span id="res-382448">
-                 <a href="/tests/382448">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382448">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382448/modules/installcheck/steps/17">
-            installcheck
-        </a>
-    </span>
+            <a href="/tests/382448/modules/installcheck/steps/17">
+	                installcheck
+			        </a>
+				    </span>
 
              <span id="test-label-382448">
-        <i class="test-label label_fixed_Build1503 fa fa-bookmark" title="fixed_Build1503"></i>
-    </span>
+	             <i class="test-label label_fixed_Build1503 fa fa-bookmark" title="fixed_Build1503"></i>
+		         </span>
 
 </td>
 
@@ -1039,27 +1039,27 @@
                             <td id="res_Gnome-DVD_x86_64_installcheck">
 
              <span id="res-382518">
-                 <a href="/tests/382518">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382518">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382518/modules/installcheck/steps/17">
-            installcheck
-        </a>
-    </span>
+            <a href="/tests/382518/modules/installcheck/steps/17">
+	                installcheck
+			        </a>
+				    </span>
 
              <span id="test-label-382518">
-        <i class="test-label label_fixed_Build1501 fa fa-bookmark" title="fixed_Build1501"></i>
-    </span>
+	             <i class="test-label label_fixed_Build1501 fa fa-bookmark" title="fixed_Build1501"></i>
+		         </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">iscsi_client</td>
+		                        <tr>
+					                        <td class="name">iscsi_client</td>
 
                                 <td>-</td>
 
@@ -1068,14 +1068,14 @@
                             <td id="res_Gnome-DVD_x86_64_iscsi_client">
 
              <a href="/tests/382680">
-                 <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
-             </a>
+	                      <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
+			                   </a>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">iscsi_ibft</td>
+		                        <tr>
+					                        <td class="name">iscsi_ibft</td>
 
                                 <td>-</td>
 
@@ -1084,29 +1084,29 @@
                             <td id="res_Gnome-DVD_x86_64_iscsi_ibft">
 
              <span id="res-382634">
-                 <a href="/tests/382634">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382634">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>preparing-disk-overview-20160304</li><li>preparing-disk-overview-20160504</li><li>preparing-disk-overview-existing-partitions-20160304</li><li>preparing-disk-overview-existing-partitions-20160508</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382634/modules/partitioning_iscsi/steps/4">
-            partitioning_iscsi
-        </a>
-    </span>
+            <a href="/tests/382634/modules/partitioning_iscsi/steps/4">
+	                partitioning_iscsi
+			        </a>
+				    </span>
 
              <span id="bug-382634">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">iscsi_server</td>
+		                        <tr>
+					                        <td class="name">iscsi_server</td>
 
                                 <td>-</td>
 
@@ -1115,29 +1115,29 @@
                             <td id="res_Gnome-DVD_x86_64_iscsi_server">
 
              <a href="/tests/382539">
-                 <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
-             </a>
+	                      <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
+			                   </a>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">lvm</td>
+		                        <tr>
+					                        <td class="name">lvm</td>
 
                             <td id="res_Gnome-DVD_arm_lvm">
 
              <span id="res-382461">
-                 <a href="/tests/382461">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382461">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382461/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382461/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -1148,24 +1148,24 @@
                             <td id="res_Gnome-DVD_x86_64_lvm">
 
              <span id="res-382575">
-                 <a href="/tests/382575">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382575">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382575/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382575/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">lvm+RAID1</td>
+		                        <tr>
+					                        <td class="name">lvm+RAID1</td>
 
                                 <td>-</td>
 
@@ -1174,26 +1174,26 @@
                             <td id="res_Gnome-DVD_x86_64_lvm+RAID1">
 
              <span id="res-382576">
-                 <a href="/tests/382576">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382576">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">mediacheck</td>
+		                        <tr>
+					                        <td class="name">mediacheck</td>
 
                             <td id="res_Gnome-DVD_arm_mediacheck">
 
              <span id="res-382462">
-                 <a href="/tests/382462">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382462">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -1205,18 +1205,18 @@
                             <td id="res_Gnome-DVD_x86_64_mediacheck">
 
              <span id="res-382577">
-                 <a href="/tests/382577">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382577">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">memtest</td>
+		                        <tr>
+					                        <td class="name">memtest</td>
 
                                 <td>-</td>
 
@@ -1225,18 +1225,18 @@
                             <td id="res_Gnome-DVD_x86_64_memtest">
 
              <span id="res-382578">
-                 <a href="/tests/382578">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382578">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.1</td>
+		                        <tr>
+					                        <td class="name">upgrade_offline_13.1</td>
 
                                 <td>-</td>
 
@@ -1245,29 +1245,29 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1">
 
              <span id="res-382608">
-                 <a href="/tests/382608">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382608">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>rebootnow-20131217</li><li>rebootnow-20150409</li><li>rebootnow-20160430</li><li>rebootnow-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382608/modules/install_and_reboot/steps/10">
-            install_and_reboot
-        </a>
-    </span>
+            <a href="/tests/382608/modules/install_and_reboot/steps/10">
+	                install_and_reboot
+			        </a>
+				    </span>
 
              <span id="bug-382608">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.1+gcc5">upgrade_offline_13.1_sp ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_offline_13.1+gcc5">upgrade_offline_13.1_sp ...</span></td>
 
                                 <td>-</td>
 
@@ -1276,29 +1276,29 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1+gcc5">
 
              <span id="res-382523">
-                 <a href="/tests/382523">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382523">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382523/modules/installation_overview/steps/13">
-            installation_overview
-        </a>
-    </span>
+            <a href="/tests/382523/modules/installation_overview/steps/13">
+	                installation_overview
+			        </a>
+				    </span>
 
              <span id="bug-382523">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.1_allpatterns">upgrade_offline_13.1_sp ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_offline_13.1_allpatterns">upgrade_offline_13.1_sp ...</span></td>
 
                                 <td>-</td>
 
@@ -1307,29 +1307,28 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1_allpatterns">
 
              <span id="res-382609">
-                 <a href="/tests/382609">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382609">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>rebootnow-20131217</li><li>rebootnow-20150409</li><li>rebootnow-20160430</li><li>rebootnow-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382609/modules/install_and_reboot/steps/11">
-            install_and_reboot
-        </a>
-    </span>
+            <a href="/tests/382609/modules/install_and_reboot/steps/11">
+	                install_and_reboot
+			        </a>
+				    </span>
 
              <span id="bug-382609">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
-
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.2</td>
+		                        <tr>
+					                        <td class="name">upgrade_offline_13.2</td>
 
                                 <td>-</td>
 
@@ -1338,18 +1337,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2">
 
              <span id="res-382610">
-                 <a href="/tests/382610">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382610">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2_allpatterns">upgrade_offline_13.2_al ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_offline_13.2_allpatterns">upgrade_offline_13.2_al ...</span></td>
 
                                 <td>-</td>
 
@@ -1358,34 +1357,34 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2_allpatterns">
 
              <span id="res-382611">
-                 <a href="/tests/382611">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382611">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2_allpatterns_arm">upgrade_offline_13.2_al ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_offline_13.2_allpatterns_arm">upgrade_offline_13.2_al ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_upgrade_offline_13.2_allpatterns_arm">
 
              <span id="res-382465">
-                 <a href="/tests/382465">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382465">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382465/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
-         +2
+            <a href="/tests/382465/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
+				             +2
 
 
 </td>
@@ -1394,31 +1393,31 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.2_arm</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">upgrade_offline_13.2_arm</td>
 
                             <td id="res_Gnome-DVD_arm_upgrade_offline_13.2_arm">
 
              <span id="res-382466">
-                 <a href="/tests/382466">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382466">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382466/modules/snapper_undochange/steps/8">
-            snapper_undochange
-        </a>
-    </span>
-         +3
+            <a href="/tests/382466/modules/snapper_undochange/steps/8">
+	                snapper_undochange
+			        </a>
+				    </span>
+				             +3
 
              <span id="bug-382466">
-        <a href="9580">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#9714, poo#9580"></i>
-        </a>
-    </span>
+	             <a href="9580">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#9714, poo#9580"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -1426,9 +1425,9 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.2_gcc5</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">upgrade_offline_13.2_gcc5</td>
 
                                 <td>-</td>
 
@@ -1437,18 +1436,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2_gcc5">
 
              <span id="res-382613">
-                 <a href="/tests/382613">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382613">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.2sp1</td>
+		                        <tr>
+					                        <td class="name">upgrade_offline_13.2sp1</td>
 
                                 <td>-</td>
 
@@ -1457,18 +1456,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1">
 
              <span id="res-382632">
-                 <a href="/tests/382632">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382632">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2sp1_allpatterns">upgrade_offline_13.2sp1 ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_offline_13.2sp1_allpatterns">upgrade_offline_13.2sp1 ...</span></td>
 
                                 <td>-</td>
 
@@ -1477,45 +1476,45 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1_allpatterns">
 
              <span id="res-382633">
-                 <a href="/tests/382633">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382633">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>GNOME-20140701</li><li>GNOME-20141210</li><li>GNOME-smartneedle-20150803</li><li>GNOME-smartneedle-20160211</li><li>GNOME-workaround-BSC978076-20160502</li><li>GNOME-workaround-BSC978076-20160504</li><li>GNOME-workaround-BSC978076-20160505</li><li>GNOME-workaround-BSC978076-20160506</li><li>GNOME-workaround-BSC978076-20160508</li><li>GNOME-workaround-BSC979072-20160509</li><li>first_boot-generic-desktop-20160503</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382633/modules/gnome_control_center/steps/11">
-            gnome_control_center
-        </a>
-    </span>
+            <a href="/tests/382633/modules/gnome_control_center/steps/11">
+	                gnome_control_center
+			        </a>
+				    </span>
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2sp1_allpatterns_arm">upgrade_offline_13.2sp1 ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_offline_13.2sp1_allpatterns_arm">upgrade_offline_13.2sp1 ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_upgrade_offline_13.2sp1_allpatterns_arm">
 
              <span id="res-382464">
-                 <a href="/tests/382464">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382464">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>rebootnow-20131217</li><li>rebootnow-20150409</li><li>rebootnow-20160430</li><li>rebootnow-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382464/modules/install_and_reboot/steps/12">
-            install_and_reboot
-        </a>
-    </span>
+            <a href="/tests/382464/modules/install_and_reboot/steps/12">
+	                install_and_reboot
+			        </a>
+				    </span>
 
              <span id="bug-382464">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -1523,24 +1522,24 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2sp1_arm">upgrade_offline_13.2sp1 ...</span></td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name"><span title="upgrade_offline_13.2sp1_arm">upgrade_offline_13.2sp1 ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_upgrade_offline_13.2sp1_arm">
 
              <span id="res-382463">
-                 <a href="/tests/382463">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382463">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382463/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382463/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -1549,9 +1548,9 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga">upgrade_zdup_offline_sle ...</span></td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga">upgrade_zdup_offline_sle ...</span></td>
 
                                 <td>-</td>
 
@@ -1560,18 +1559,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga">
 
              <span id="res-382614">
-                 <a href="/tests/382614">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382614">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns">upgrade_zdup_offline_sle ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns">upgrade_zdup_offline_sle ...</span></td>
 
                                 <td>-</td>
 
@@ -1580,18 +1579,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga_allpatterns">
 
              <span id="res-382615">
-                 <a href="/tests/382615">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382615">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
 
                                 <td>-</td>
 
@@ -1600,33 +1599,33 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga_allpatterns+workaround_deps">
 
              <span id="res-382616">
-                 <a href="/tests/382616">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382616">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns_arm">upgrade_zdup_offline_sle ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns_arm">upgrade_zdup_offline_sle ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_upgrade_zdup_offline_13.2_ga_allpatterns_arm">
 
              <span id="res-382467">
-                 <a href="/tests/382467">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382467">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382467/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382467/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -1635,31 +1634,31 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_arm">upgrade_zdup_offline_sle ...</span></td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_arm">upgrade_zdup_offline_sle ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_upgrade_zdup_offline_13.2_ga_arm">
 
              <span id="res-382468">
-                 <a href="/tests/382468">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382468">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382468/modules/snapper_undochange/steps/8">
-            snapper_undochange
-        </a>
-    </span>
-         +2
+            <a href="/tests/382468/modules/snapper_undochange/steps/8">
+	                snapper_undochange
+			        </a>
+				    </span>
+				             +2
 
              <span id="bug-382468">
-        <a href="9580">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#9714, poo#9580"></i>
-        </a>
-    </span>
+	             <a href="9580">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#9714, poo#9580"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -1667,9 +1666,9 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1">upgrade_zdup_offline_sle ...</span></td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1">upgrade_zdup_offline_sle ...</span></td>
 
                                 <td>-</td>
 
@@ -1678,18 +1677,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1">
 
              <span id="res-382601">
-                 <a href="/tests/382601">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382601">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns">upgrade_zdup_offline_sle ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns">upgrade_zdup_offline_sle ...</span></td>
 
                                 <td>-</td>
 
@@ -1698,18 +1697,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1_allpatterns">
 
              <span id="res-382600">
-                 <a href="/tests/382600">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382600">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
 
                                 <td>-</td>
 
@@ -1718,18 +1717,18 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1_allpatterns+workaround_deps">
 
              <span id="res-382602">
-                 <a href="/tests/382602">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382602">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_online_13.2_ga">upgrade_zdup_online_sle1 ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="upgrade_zdup_online_13.2_ga">upgrade_zdup_online_sle1 ...</span></td>
 
                                 <td>-</td>
 
@@ -1738,39 +1737,39 @@
                             <td id="res_Gnome-DVD_x86_64_upgrade_zdup_online_13.2_ga">
 
              <span id="res-382617">
-                 <a href="/tests/382617">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382617">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">minimal+base</td>
+		                        <tr>
+					                        <td class="name">minimal+base</td>
 
                             <td id="res_Gnome-DVD_arm_minimal+base">
 
              <span id="res-382469">
-                 <a href="/tests/382469">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382469">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382469/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382469/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382469/modules/yast2_bootloader/steps/7">
-            <span title="yast2_bootloader">yast2_bootlo ...</span>
-        </a>
-    </span>
+            <a href="/tests/382469/modules/yast2_bootloader/steps/7">
+	                <span title="yast2_bootloader">yast2_bootlo ...</span>
+			        </a>
+				    </span>
 
 
 </td>
@@ -1779,23 +1778,23 @@
                             <td id="res_Gnome-DVD_i586_minimal+base">
 
              <span id="res-382494">
-                 <a href="/tests/382494">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382494">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382494/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382494/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
              <span id="bug-382494">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -1803,51 +1802,51 @@
                             <td id="res_Gnome-DVD_x86_64_minimal+base">
 
              <span id="res-382618">
-                 <a href="/tests/382618">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382618">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382618/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382618/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li>yast2_nfs_server-conf-20160128</li><li>yast2_nfs_server-nfs-firewall-20160128</li><li>yast2_nfs_server-nfs-server-not-installed-20160303</li><li>yast2_nfs_server-nfs-server-not-installed-20160405</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382618/modules/yast2_nfs_server/steps/9">
-            <span title="yast2_nfs_server">yast2_nfs_se ...</span>
-        </a>
-    </span>
+            <a href="/tests/382618/modules/yast2_nfs_server/steps/9">
+	                <span title="yast2_nfs_server">yast2_nfs_se ...</span>
+			        </a>
+				    </span>
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">minimal+base+awesome</td>
+		                        <tr>
+					                        <td class="name">minimal+base+awesome</td>
 
                             <td id="res_Gnome-DVD_arm_minimal+base+awesome">
 
              <span id="res-382470">
-                 <a href="/tests/382470">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382470">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382470/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382470/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382470/modules/yast2_bootloader/steps/5">
-            <span title="yast2_bootloader">yast2_bootlo ...</span>
-        </a>
-    </span>
+            <a href="/tests/382470/modules/yast2_bootloader/steps/5">
+	                <span title="yast2_bootloader">yast2_bootlo ...</span>
+			        </a>
+				    </span>
 
 
 </td>
@@ -1858,40 +1857,40 @@
                             <td id="res_Gnome-DVD_x86_64_minimal+base+awesome">
 
              <span id="res-382619">
-                 <a href="/tests/382619">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382619">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382619/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382619/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li>yast2_nfs_server-conf-20160128</li><li>yast2_nfs_server-nfs-firewall-20160128</li><li>yast2_nfs_server-nfs-server-not-installed-20160303</li><li>yast2_nfs_server-nfs-server-not-installed-20160405</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382619/modules/yast2_nfs_server/steps/9">
-            <span title="yast2_nfs_server">yast2_nfs_se ...</span>
-        </a>
-    </span>
+            <a href="/tests/382619/modules/yast2_nfs_server/steps/9">
+	                <span title="yast2_nfs_server">yast2_nfs_se ...</span>
+			        </a>
+				    </span>
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="minimal+base@i586--l2">minimal+base@i586--vsw ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="minimal+base@i586--l2">minimal+base@i586--vsw ...</span></td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_minimal+base@i586--l2">
 
              <span id="res-382492">
-                 <a href="/tests/382492">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382492">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -1899,24 +1898,24 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">minimal_x</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">minimal_x</td>
 
                             <td id="res_Gnome-DVD_arm_minimal_x">
 
              <span id="res-382471">
-                 <a href="/tests/382471">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382471">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382471/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382471/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -1927,18 +1926,18 @@
                             <td id="res_Gnome-DVD_x86_64_minimal_x">
 
              <span id="res-382620">
-                 <a href="/tests/382620">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382620">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">minimal_x+uefi@uefi</td>
+		                        <tr>
+					                        <td class="name">minimal_x+uefi@uefi</td>
 
                                 <td>-</td>
 
@@ -1947,18 +1946,18 @@
                             <td id="res_Gnome-DVD_x86_64_minimal_x+uefi@uefi">
 
              <span id="res-382621">
-                 <a href="/tests/382621">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382621">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">multipath</td>
+		                        <tr>
+					                        <td class="name">multipath</td>
 
                                 <td>-</td>
 
@@ -1967,26 +1966,26 @@
                             <td id="res_Gnome-DVD_x86_64_multipath">
 
              <span id="res-382622">
-                 <a href="/tests/382622">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382622">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">rescue_system_13.1sp4</td>
+		                        <tr>
+					                        <td class="name">rescue_system_13.1sp4</td>
 
                             <td id="res_Gnome-DVD_arm_rescue_system_13.1sp4">
 
              <span id="res-382472">
-                 <a href="/tests/382472">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382472">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -1998,18 +1997,18 @@
                             <td id="res_Gnome-DVD_x86_64_rescue_system_13.1sp4">
 
              <span id="res-382623">
-                 <a href="/tests/382623">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382623">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2018,35 +2017,35 @@
                             <td id="res_Gnome-DVD_x86_64_rollback_upgrade_offline_13.2">
 
              <span id="res-382638">
-                 <a href="/tests/382638">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382638">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>GNOME-20140701</li><li>GNOME-20141210</li><li>GNOME-smartneedle-20150803</li><li>GNOME-smartneedle-20160211</li><li>GNOME-workaround-BSC978076-20160502</li><li>GNOME-workaround-BSC978076-20160504</li><li>GNOME-workaround-BSC978076-20160505</li><li>GNOME-workaround-BSC978076-20160506</li><li>GNOME-workaround-BSC978076-20160508</li><li>GNOME-workaround-BSC979072-20160509</li><li>first_boot-generic-desktop-20160503</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382638/modules/snapper_rollback/steps/14">
-            snapper_rollback
-        </a>
-    </span>
+            <a href="/tests/382638/modules/snapper_rollback/steps/14">
+	                snapper_rollback
+			        </a>
+				    </span>
 
              <span id="bug-382638">
-        <a href="https://progress.opensuse.org/issues/9580">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#9580"></i>
-        </a>
-    </span>
+	             <a href="https://progress.opensuse.org/issues/9580">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#9580"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2_arm">rollback_upgrade_offline ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="rollback_upgrade_offline_13.2_arm">rollback_upgrade_offline</span></td>
 
                             <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2_arm">
 
              <a href="/tests/382485">
-                 <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
-             </a>
+	                      <i class="status state_cancelled fa fa-circle" title="cancelled">
+			      </a>
 
 </td>
 
@@ -2054,9 +2053,9 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline ...</span></td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2065,46 +2064,46 @@
                             <td id="res_Gnome-DVD_x86_64_rollback_upgrade_offline_13.2sp1">
 
              <span id="res-382671">
-                 <a href="/tests/382671">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382671">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>snap-before-update-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382671/modules/grub_test_snapshot/steps/48">
-            grub_test_snapshot
-        </a>
-    </span>
+            <a href="/tests/382671/modules/grub_test_snapshot/steps/48">
+	                grub_test_snapshot
+			        </a>
+				    </span>
 
              <span id="test-label-382671">
-        <i class="test-label label_broken_test fa fa-bookmark" title="broken_test"></i>
-    </span>
+	             <i class="test-label label_broken_test fa fa-bookmark" title="broken_test"></i>
+		         </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1_arm">rollback_upgrade_offline ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1_arm">rollback_upgrade_offline</span></td>
 
                             <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2sp1_arm">
 
              <span id="res-382486">
-                 <a href="/tests/382486">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382486">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>bootmenu-SLES-12-20160311</li><li>bootmenu-SLES-42.1-20160216</li><li>bootmenu-SLES-42.1-20160314</li><li>grub2-20151117</li><li>grub2-ofw-20160225</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382486/modules/grub_test_snapshot/steps/4">
-            grub_test_snapshot
-        </a>
-    </span>
+            <a href="/tests/382486/modules/grub_test_snapshot/steps/4">
+	                grub_test_snapshot
+			        </a>
+				    </span>
 
              <span id="test-label-382486">
-        <i class="test-label label_broken_test fa fa-bookmark" title="broken_test"></i>
-    </span>
+	             <i class="test-label label_broken_test fa fa-bookmark" title="broken_test"></i>
+		         </span>
 
 </td>
 
@@ -2112,24 +2111,24 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gcc5</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">gcc5</td>
 
                             <td id="res_Gnome-DVD_arm_gcc5">
 
              <span id="res-382473">
-                 <a href="/tests/382473">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382473">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382473/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382473/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -2140,33 +2139,33 @@
                             <td id="res_Gnome-DVD_x86_64_gcc5">
 
              <span id="res-382624">
-                 <a href="/tests/382624">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382624">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">gcc5+allpatterns</td>
+		                        <tr>
+					                        <td class="name">gcc5+allpatterns</td>
 
                             <td id="res_Gnome-DVD_arm_gcc5+allpatterns">
 
              <span id="res-382474">
-                 <a href="/tests/382474">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382474">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382474/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382474/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -2177,33 +2176,33 @@
                             <td id="res_Gnome-DVD_x86_64_gcc5+allpatterns">
 
              <span id="res-382625">
-                 <a href="/tests/382625">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382625">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">gcc5-ftp</td>
+		                        <tr>
+					                        <td class="name">gcc5-ftp</td>
 
                             <td id="res_Gnome-DVD_arm_gcc5-ftp">
 
              <span id="res-382445">
-                 <a href="/tests/382445">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382445">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382445/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382445/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -2214,28 +2213,28 @@
                             <td id="res_Gnome-DVD_x86_64_gcc5-ftp">
 
              <span id="res-382514">
-                 <a href="/tests/382514">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382514">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">gcc5-ftp@i586--l3</td>
+		                        <tr>
+					                        <td class="name">gcc5-ftp@i586--l3</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_gcc5-ftp@i586--l3">
 
              <span id="res-382488">
-                 <a href="/tests/382488">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382488">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2243,24 +2242,24 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gcc5-http</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">gcc5-http</td>
 
                             <td id="res_Gnome-DVD_arm_gcc5-http">
 
              <span id="res-382446">
-                 <a href="/tests/382446">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382446">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382446/modules/yast2_bootloader/steps/5">
-            yast2_bootloader
-        </a>
-    </span>
+            <a href="/tests/382446/modules/yast2_bootloader/steps/5">
+	                yast2_bootloader
+			        </a>
+				    </span>
 
 
 </td>
@@ -2271,44 +2270,44 @@
                             <td id="res_Gnome-DVD_x86_64_gcc5-http">
 
              <span id="res-382515">
-                 <a href="/tests/382515">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382515">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>gnome_terminal-20140319</li><li>gnome_terminal-20140604</li><li>gnome_terminal-20140729</li><li>gnome_terminal-20160502</li><li>gnome_terminal-20160509</li><li>gnome_terminal-workaround-bsc962806-20160126</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382515/modules/gnome_terminal/steps/4">
-            gnome_terminal
-        </a>
-    </span>
-         +1
+            <a href="/tests/382515/modules/gnome_terminal/steps/4">
+	                gnome_terminal
+			        </a>
+				    </span>
+				             +1
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">leap+extratests</td>
+		                        <tr>
+					                        <td class="name">leap+extratests</td>
 
                             <td id="res_Gnome-DVD_arm_leap+extratests">
 
              <span id="res-382481">
-                 <a href="/tests/382481">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382481">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>displaymanager-20140621</li><li>displaymanager-20160502</li><li>displaymanager-20160506</li><li>gdm-workaround-bsc962806-20160125</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382481/modules/boot_to_desktop/steps/5">
-            boot_to_desktop
-        </a>
-    </span>
+            <a href="/tests/382481/modules/boot_to_desktop/steps/5">
+	                boot_to_desktop
+			        </a>
+				    </span>
 
              <span id="test-label-382481">
-        <i class="test-label label_zluo fa fa-bookmark" title="zluo"></i>
-    </span>
+	             <i class="test-label label_zluo fa fa-bookmark" title="zluo"></i>
+		         </span>
 
 </td>
 
@@ -2318,22 +2317,22 @@
                             <td id="res_Gnome-DVD_x86_64_leap+extratests">
 
              <a href="/tests/382644">
-                 <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
-             </a>
+	                      <i class="status state_cancelled fa fa-circle" title="cancelled"></i>
+			                   </a>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">create_hdd_textmode</td>
+		                        <tr>
+					                        <td class="name">create_hdd_textmode</td>
 
                             <td id="res_Gnome-DVD_arm_create_hdd_textmode">
 
              <span id="res-382450">
-                 <a href="/tests/382450">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382450">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2345,37 +2344,37 @@
                             <td id="res_Gnome-DVD_x86_64_create_hdd_textmode">
 
              <span id="res-382526">
-                 <a href="/tests/382526">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382526">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>tty2-selected-20151201</li><li>tty2-selected-20160508</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382526/modules/hostname/steps/2">
-            hostname
-        </a>
-    </span>
+            <a href="/tests/382526/modules/hostname/steps/2">
+	                hostname
+			        </a>
+				    </span>
 
              <span id="bug-382526">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_minimal_base+gcc5_create_hdd">leap12_minimal_base+gcc5_cr ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="leap12_minimal_base+gcc5_create_hdd">leap12_minimal_base+gcc5_cr ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_leap12_minimal_base+gcc5_create_hdd">
 
              <span id="res-382451">
-                 <a href="/tests/382451">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382451">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2387,26 +2386,26 @@
                             <td id="res_Gnome-DVD_x86_64_leap12_minimal_base+gcc5_create_hdd">
 
              <span id="res-382527">
-                 <a href="/tests/382527">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382527">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_qa_acceptance_fs_stress">leap12_qa_acceptance_fs_st ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="leap12_qa_acceptance_fs_stress">leap12_qa_acceptance_fs_st ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_fs_stress">
 
              <span id="res-382482">
-                 <a href="/tests/382482">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382482">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2418,26 +2417,26 @@
                             <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_fs_stress">
 
              <span id="res-382645">
-                 <a href="/tests/382645">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382645">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_qa_acceptance_process_stress">leap12_qa_acceptance_proce ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="leap12_qa_acceptance_process_stress">leap12_qa_acceptance_proce ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_process_stress">
 
              <span id="res-382483">
-                 <a href="/tests/382483">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382483">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2449,26 +2448,26 @@
                             <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_process_stress">
 
              <span id="res-382646">
-                 <a href="/tests/382646">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382646">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_qa_acceptance_sched_stress">leap12_qa_acceptance_sched ...</span></td>
+		                        <tr>
+					                        <td class="name"><span title="leap12_qa_acceptance_sched_stress">leap12_qa_acceptance_sched ...</span></td>
 
                             <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_sched_stress">
 
              <span id="res-382484">
-                 <a href="/tests/382484">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382484">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2480,68 +2479,68 @@
                             <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_sched_stress">
 
              <span id="res-382647">
-                 <a href="/tests/382647">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382647">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">ssh-X@i586--l3</td>
+		                        <tr>
+					                        <td class="name">ssh-X@i586--l3</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_ssh-X@i586--l3">
 
              <span id="res-382797">
-                 <a href="/tests/382797">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382797">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>bootloader_i586-yast2-windowborder-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382797/modules/bootloader_i586/steps/11">
-            bootloader_i586
-        </a>
-    </span>
+            <a href="/tests/382797/modules/bootloader_i586/steps/11">
+	                bootloader_i586
+			        </a>
+				    </span>
 
              <span id="test-label-382797">
-        <i class="test-label label_not_deployed_yet fa fa-bookmark" title="not_deployed_yet"></i>
-    </span>
+	             <i class="test-label label_not_deployed_yet fa fa-bookmark" title="not_deployed_yet"></i>
+		         </span>
 
 </td>
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">textmode</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">textmode</td>
 
                             <td id="res_Gnome-DVD_arm_textmode">
 
              <span id="res-382475">
-                 <a href="/tests/382475">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382475">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382475/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382475/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382475/modules/yast2_bootloader/steps/5">
-            <span title="yast2_bootloader">yast2_bootlo ...</span>
-        </a>
-    </span>
+            <a href="/tests/382475/modules/yast2_bootloader/steps/5">
+	                <span title="yast2_bootloader">yast2_bootlo ...</span>
+			        </a>
+				    </span>
 
 
 </td>
@@ -2550,23 +2549,23 @@
                             <td id="res_Gnome-DVD_i586_textmode">
 
              <span id="res-382507">
-                 <a href="/tests/382507">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382507">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382507/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382507/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
              <span id="bug-382507">
-        <a href="https://progress.opensuse.org/issues/11074">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#11074"></i>
-        </a>
-    </span>
+	             <a href="https://progress.opensuse.org/issues/11074">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: poo#11074"></i>
+				         </a>
+					     </span>
 
 </td>
 
@@ -2574,51 +2573,51 @@
                             <td id="res_Gnome-DVD_x86_64_textmode">
 
              <span id="res-382628">
-                 <a href="/tests/382628">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382628">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382628/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382628/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li>yast2_nfs_server-conf-20160128</li><li>yast2_nfs_server-nfs-firewall-20160128</li><li>yast2_nfs_server-nfs-server-not-installed-20160303</li><li>yast2_nfs_server-nfs-server-not-installed-20160405</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382628/modules/yast2_nfs_server/steps/9">
-            <span title="yast2_nfs_server">yast2_nfs_se ...</span>
-        </a>
-    </span>
+            <a href="/tests/382628/modules/yast2_nfs_server/steps/9">
+	                <span title="yast2_nfs_server">yast2_nfs_se ...</span>
+			        </a>
+				    </span>
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">textmode+awesome</td>
+		                        <tr>
+					                        <td class="name">textmode+awesome</td>
 
                             <td id="res_Gnome-DVD_arm_textmode+awesome">
 
              <span id="res-382479">
-                 <a href="/tests/382479">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382479">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382479/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382479/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li></li><li>yast2_bootloader-20150122</li><li>yast2_bootloader-20150410</li><li>yast2_bootloader-20150923</li><li>yast2_bootloader-20160404</li><li>yast2_bootloader-20160420</li><li>yast2_bootloader-IPMI-20160411</li><li>yast2_bootloader-UEFI-20140930</li><li>yast2_bootloader-UEFI-20160420</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382479/modules/yast2_bootloader/steps/5">
-            <span title="yast2_bootloader">yast2_bootlo ...</span>
-        </a>
-    </span>
+            <a href="/tests/382479/modules/yast2_bootloader/steps/5">
+	                <span title="yast2_bootloader">yast2_bootlo ...</span>
+			        </a>
+				    </span>
 
 
 </td>
@@ -2629,40 +2628,40 @@
                             <td id="res_Gnome-DVD_x86_64_textmode+awesome">
 
              <span id="res-382629">
-                 <a href="/tests/382629">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382629">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/382629/modules/dns_srv/steps/10">
-            dns_srv
-        </a>
-    </span>
+            <a href="/tests/382629/modules/dns_srv/steps/10">
+	                dns_srv
+			        </a>
+				    </span>
 
     <span title='<p>Failed needles:</p><ul><li>yast2_nfs_server-conf-20160128</li><li>yast2_nfs_server-nfs-firewall-20160128</li><li>yast2_nfs_server-nfs-server-not-installed-20160303</li><li>yast2_nfs_server-nfs-server-not-installed-20160405</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382629/modules/yast2_nfs_server/steps/9">
-            <span title="yast2_nfs_server">yast2_nfs_se ...</span>
-        </a>
-    </span>
+            <a href="/tests/382629/modules/yast2_nfs_server/steps/9">
+	                <span title="yast2_nfs_server">yast2_nfs_se ...</span>
+			        </a>
+				    </span>
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">textmode@i586--l3</td>
+		                        <tr>
+					                        <td class="name">textmode@i586--l3</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_textmode@i586--l3">
 
              <span id="res-382785">
-                 <a href="/tests/382785">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382785">
+			                           <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2670,19 +2669,19 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">toolchain_zypper</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">toolchain_zypper</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_toolchain_zypper">
 
              <span id="res-383540">
-                 <a href="/tests/383540">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/383540">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2690,9 +2689,9 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">toolchain_zypper@64bit-smp</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">toolchain_zypper@64bit-smp</td>
 
                                 <td>-</td>
 
@@ -2701,26 +2700,26 @@
                             <td id="res_Gnome-DVD_x86_64_toolchain_zypper@64bit-smp">
 
              <span id="res-382522">
-                 <a href="/tests/382522">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382522">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">toolchain_zypper@arm-smp</td>
+		                        <tr>
+					                        <td class="name">toolchain_zypper@arm-smp</td>
 
                             <td id="res_Gnome-DVD_arm_toolchain_zypper@arm-smp">
 
              <span id="res-382449">
-                 <a href="/tests/382449">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382449">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2730,9 +2729,9 @@
                                 <td>-</td>
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">we</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">we</td>
 
                                 <td>-</td>
 
@@ -2743,18 +2742,18 @@
                             <td id="res_Gnome-DVD_x86_64_we">
 
              <span id="res-382524">
-                 <a href="/tests/382524">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382524">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">we+allpatterns</td>
+		                        <tr>
+					                        <td class="name">we+allpatterns</td>
 
                                 <td>-</td>
 
@@ -2763,30 +2762,30 @@
                             <td id="res_Gnome-DVD_x86_64_we+allpatterns">
 
              <span id="res-382525">
-                 <a href="/tests/382525">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382525">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>desktop_mainmenu-1-20160411</li><li>desktop_mainmenu-gnome-20140813</li><li>desktop_mainmenu-gnomesled-20141205</li><li>desktop_mainmenu-ipmi-20160419</li><li>desktop_mainmenu-sled-20160503</li><li>desktop_mainmenu-sled-20160504</li><li>desktop_mainmenu-sled-20160506</li><li>desktop_mainmenu-leap_we-20160509</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382525/modules/desktop_mainmenu/steps/4">
-            desktop_mainmenu
-        </a>
-    </span>
-         +2
+            <a href="/tests/382525/modules/desktop_mainmenu/steps/4">
+	                desktop_mainmenu
+			        </a>
+				    </span>
+				             +2
 
              <span id="bug-382525">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">we-ftp</td>
+		                        <tr>
+					                        <td class="name">we-ftp</td>
 
                                 <td>-</td>
 
@@ -2795,29 +2794,61 @@
                             <td id="res_Gnome-DVD_x86_64_we-ftp">
 
              <span id="res-382516">
-                 <a href="/tests/382516">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382516">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>desktop_mainmenu-1-20160411</li><li>desktop_mainmenu-gnome-20140813</li><li>desktop_mainmenu-gnomesled-20141205</li><li>desktop_mainmenu-ipmi-20160419</li><li>desktop_mainmenu-sled-20160503</li><li>desktop_mainmenu-sled-20160504</li><li>desktop_mainmenu-sled-20160506</li><li>desktop_mainmenu-leap_we-20160509</li><li>tty2-selected-20151201</li><li>tty2-selected-20160508</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382516/modules/desktop_mainmenu/steps/3">
-            desktop_mainmenu
-        </a>
-    </span>
+    <span title='<p>Failed needles:</p><ul><li>desktop_mainmenu-1-20160411</li><li>desktop_mainmenu-1-20160411</li><li>desktop_mainmenu-gnome-20140813</li><li>desktop_mainmenu-gnomesled-20141205</li><li>desktop_mainmenu-ipmi-20160419</li><li>desktop_mainmenu-sled-20160503</li><li>desktop_mainmenu-sled-20160504</li><li>desktop_mainmenu-sled-20160506</li><li>desktop_mainmenu-leap_we-20160509</li></ul>' data-toggle='tooltip' class="failedmodule" >
+            <a href="/tests/382525/modules/desktop_mainmenu/steps/4">
+	                desktop_mainmenu
+			        </a>
+				    </span>
+				             +2
 
-             <span id="bug-382516">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+             <span id="bug-382525">
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">we-http</td>
+		                        <tr>
+					                        <td class="name">we-ftp</td>
+
+                                <td>-</td>
+
+                                <td>-</td>
+
+                            <td id="res_Gnome-DVD_x86_64_we-ftp">
+
+             <span id="res-382516">
+	                      <a href="/tests/382516">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
+
+
+    <span title='<p>Failed needles:</p><ul><li>desktop_mainmenu-1-20160411</li><li>desktop_mainmenu-gnome-20140813</li><li>desktop_mainmenu-gnomesled-20141205</li><li>desktop_mainmenu-ipmi-20160419</li><li>desktop_mainmenu-sled-20160503</li><li>desktop_mainmenu-sled-20160504</li><li>desktop_mainmenu-sled-20160506</li><li>desktop_mainmenu-leap_we-20160509</li><li>tty2-selected-20151201</li><li>tty2-selected-20160508</li></ul>' data-toggle='tooltip' class="failedmodule" >
+            <a href="/tests/382516/modules/desktop_mainmenu/steps/3">
+	                desktop_mainmenu
+			        </a>
+				    </span>
+
+             <span id="bug-382516">
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
+
+</td>
+
+                    </tr>
+		                        <tr>
+					                        <td class="name">we-http</td>
 
                                 <td>-</td>
 
@@ -2826,29 +2857,29 @@
                             <td id="res_Gnome-DVD_x86_64_we-http">
 
              <span id="res-382517">
-                 <a href="/tests/382517">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382517">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>desktop_mainmenu-1-20160411</li><li>desktop_mainmenu-gnome-20140813</li><li>desktop_mainmenu-gnomesled-20141205</li><li>desktop_mainmenu-ipmi-20160419</li><li>desktop_mainmenu-sled-20160503</li><li>desktop_mainmenu-sled-20160504</li><li>desktop_mainmenu-sled-20160506</li><li>desktop_mainmenu-leap_we-20160509</li><li>tty2-selected-20151201</li><li>tty2-selected-20160508</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382517/modules/desktop_mainmenu/steps/3">
-            desktop_mainmenu
-        </a>
-    </span>
+            <a href="/tests/382517/modules/desktop_mainmenu/steps/3">
+	                desktop_mainmenu
+			        </a>
+				    </span>
 
              <span id="bug-382517">
-        <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
-        </a>
-    </span>
+	             <a href="https://bugzilla.opensuse.org/show_bug.cgi?id=822770">
+		                 <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#822770"></i>
+				         </a>
+					     </span>
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">xen</td>
+		                        <tr>
+					                        <td class="name">xen</td>
 
                                 <td>-</td>
 
@@ -2857,26 +2888,26 @@
                             <td id="res_Gnome-DVD_x86_64_xen">
 
              <span id="res-382630">
-                 <a href="/tests/382630">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382630">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">xfs</td>
+		                        <tr>
+					                        <td class="name">xfs</td>
 
                             <td id="res_Gnome-DVD_arm_xfs">
 
              <span id="res-382480">
-                 <a href="/tests/382480">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382480">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2886,10 +2917,10 @@
                             <td id="res_Gnome-DVD_i586_xfs">
 
              <span id="res-382506">
-                 <a href="/tests/382506">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382506">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2899,28 +2930,28 @@
                             <td id="res_Gnome-DVD_x86_64_xfs">
 
              <span id="res-382631">
-                 <a href="/tests/382631">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382631">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
 </td>
 
                     </tr>
-                    <tr>
-                        <td class="name">xfs@i586--l2</td>
+		                        <tr>
+					                        <td class="name">xfs@i586--l2</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_xfs@i586--l2">
 
              <span id="res-382493">
-                 <a href="/tests/382493">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382493">
+			                           <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+						                    </a>
+								                 </span>
 
 
 
@@ -2928,52 +2959,52 @@
 
 
                                 <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">zfcp@i586-zfcp</td>
+				                    </tr>
+						                        <tr>
+									                        <td class="name">zfcp@i586-zfcp</td>
 
                                 <td>-</td>
 
                             <td id="res_Gnome-DVD_i586_zfcp@i586-zfcp">
 
              <span id="res-382501">
-                 <a href="/tests/382501">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+	                      <a href="/tests/382501">
+			                           <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+						                    </a>
+								                 </span>
 
 
     <span title='<p>Failed needles:</p><ul><li></li><li>osc-registration-20150626</li><li>osc-registration-localregserver1-20140728</li><li>osc-registration-localregserver1-20160429</li><li>osc-registration-localregserver1-20160504</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/382501/modules/skip_registration/steps/2">
-            skip_registration
-        </a>
-    </span>
+            <a href="/tests/382501/modules/skip_registration/steps/2">
+	                skip_registration
+			        </a>
+				    </span>
 
              <span id="test-label-382501">
-        <i class="test-label label_hardware_issue fa fa-bookmark" title="hardware_issue"></i>
-    </span>
+	             <i class="test-label label_hardware_issue fa fa-bookmark" title="hardware_issue"></i>
+		         </span>
 
 </td>
 
 
                                 <td>-</td>
-                    </tr>
-            </tbody>
-        </table>
-</div>
+				                    </tr>
+						                </tbody>
+								        </table>
+									</div>
 
       </div>
 
       <footer class='footer'>
-      <div class='container'>
-          <div id='footer-content'>
+            <div class='container'>
+	              <div id='footer-content'>
 
               </div>
-          <div id='footer-legal'>
-                  openQA is licensed <a href="https://github.com/os-autoinst/openQA">GPL-2.0</a>
-          </div>
-      </div>
-      </footer>
-    </div>
-  </body>
-</html>
+	                <div id='footer-legal'>
+			                  openQA is licensed <a href="https://github.com/os-autoinst/openQA">GPL-2.0</a>
+					            </div>
+						          </div>
+							        </footer>
+								    </div>
+								      </body>
+								      </html>

--- a/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
+++ b/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
@@ -2392,7 +2392,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2423,7 +2423,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2_arm">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2_arm">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2441,7 +2441,7 @@
                                 <td>-</td>
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2474,7 +2474,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1_arm">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1_arm">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 

--- a/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1508%26groupid%3D25
+++ b/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1508%26groupid%3D25
@@ -2420,7 +2420,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2451,7 +2451,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2_arm">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2_arm">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2469,7 +2469,7 @@
                                 <td>-</td>
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 
@@ -2502,7 +2502,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1_arm">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1_arm">rollback_upgrade_offline</span></td>
 
                                 <td>-</td>
 

--- a/tests/tags_labels/report25_T_bugrefs.md
+++ b/tests/tags_labels/report25_T_bugrefs.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **New Product bugs:**
 
 * [toolchain_zypper](https://openqa.opensuse.org/tests/384324 "Failed modules: install") -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571)

--- a/tests/tags_labels/report25_T_bugrefs_softfails.md
+++ b/tests/tags_labels/report25_T_bugrefs_softfails.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **New Product bugs:**
 
 * [toolchain_zypper](https://openqa.opensuse.org/tests/384324 "Failed modules: install") -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571)

--- a/tests/tags_labels/report25_bugrefs.md
+++ b/tests/tags_labels/report25_bugrefs.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **New Product bugs:**
 
 * toolchain_zypper -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571)

--- a/tests/tags_labels/report25_bugrefs_abbreviated.md
+++ b/tests/tags_labels/report25_bugrefs_abbreviated.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **New Product bugs:**
 
 * [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571)

--- a/tests/tags_labels/report25_bugrefs_build1508.md
+++ b/tests/tags_labels/report25_bugrefs_build1508.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **Existing Product bugs:**
 
 * allpatterns -> [bsc#0](https://bugzilla.opensuse.org/show_bug.cgi?id=0) (NOTE: boo#0/bsc#0/poo#0 label used, please review. Consider creating progress ticket for the investigation)

--- a/tests/tags_labels/report25_bugrefs_query_issues.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **New Product bugs:**
 
 * toolchain_zypper -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571 "no space left on device when upgrading ✓") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)

--- a/tests/tags_labels/report25_bugrefs_query_issues_filter_closed.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues_filter_closed.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **Existing Product bugs:**
 
 * allpatterns, ext4@i586--l2, gnome, minimal+base -> [bsc#822770](https://bugzilla.opensuse.org/show_bug.cgi?id=822770 "Install of grub2-efi failed") (Ticket status: RESOLVED (FOOBAR), prio/severity: P5/Normal, assignee: bazifoo@gmail.com)

--- a/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
@@ -9,6 +9,12 @@
 **Arch:** i586
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* rollback_upgrade_offline
+
+
+
 **New Product bugs:**
 
 * toolchain_zypper -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571 "no space left on device when upgrading ✓") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)

--- a/tests/tags_labels/report_link_new_issue/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1500%26groupid%3D25
+++ b/tests/tags_labels/report_link_new_issue/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1500%26groupid%3D25
@@ -1,3822 +1,3822 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-      <!-- Meta, title, CSS, favicons, etc. -->
-      <meta charset="utf-8">
+    <!-- Meta, title, CSS, favicons, etc. -->
+    <meta charset="utf-8">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta name="description" content="openQA is a testing framework mainly for distributions">
-      <meta name="keywords" content="Testing, Linux, Qemu">
-      <meta name="author" content="openQA contributors">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+          <meta name="description" content="openQA is a testing framework mainly for distributions">
+            <meta name="keywords" content="Testing, Linux, Qemu">
+              <meta name="author" content="openQA contributors">
 
-      <meta name="csrf-token" content="e0be217956242a4049c8d18826990477f9151667" />
-      <meta name="csrf-param" content="csrf_token" />
+                <meta name="csrf-token" content="e0be217956242a4049c8d18826990477f9151667" />
+                <meta name="csrf-param" content="csrf_token" />
 
-      <title>openQA: Test summary</title>
+                <title>openQA: Test summary</title>
 
-      <!-- Bootstrap core CSS -->
-      <link href="/asset/90959f62a0/bootstrap.css" rel="stylesheet">
-      <script src="/asset/1e6ab518bc/bootstrap.js"></script>
-
-
-
-      <script>//<![CDATA[
+                <!-- Bootstrap core CSS -->
+                <link href="/asset/90959f62a0/bootstrap.css" rel="stylesheet">
+                  <script src="/asset/1e6ab518bc/bootstrap.js"></script>
 
 
-          $(function() {
-          setupForAll();
-            setupOverview();
 
-          } );
+                  <script>//<![CDATA[
 
-//]]></script>
-      <link rel="icon"
-            type="image/png" sizes="16x16"
-            href="/asset/5caa45a06e/logo-16.png">
-      <link rel="icon" href="/asset/3137d8fd56/logo.svg" sizes="any" type="image/svg+xml">
 
-  </head>
-  <body>
-      <nav class="navbar navbar-static-top navbar-default">
-          <div class="container">
-              <!-- Brand and toggle get grouped for better mobile display -->
-              <div class="navbar-header">
-                  <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-1" aria-expanded="false">
-                      <span class="sr-only">Toggle navigation</span>
-                      <span class="icon-bar"></span>
-                      <span class="icon-bar"></span>
-                      <span class="icon-bar"></span>
-                  </button>
-                  <a class="navbar-brand" href="/"><img src="/asset/3137d8fd56/logo.svg" alt="openQA"></a>
-              </div>
-              <!-- Collect the nav links, forms, and other content for toggling -->
-              <div class="collapse navbar-collapse" id="navbar-collapse-1">
-                  <ul class="nav navbar-nav">
+                  $(function() {
+                  setupForAll();
+                  setupOverview();
 
-                      <li>
-                          <a href="/tests">All Tests</a>
-                      </li>
+                  } );
 
-                      <li class="dropdown">
-                          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Job Groups<span class="caret"></span></a>
-                          <ul class="dropdown-menu">
+                  //]]></script>
+                  <link rel="icon"
+                        type="image/png" sizes="16x16"
+                        href="/asset/5caa45a06e/logo-16.png">
+                    <link rel="icon" href="/asset/3137d8fd56/logo.svg" sizes="any" type="image/svg+xml">
+
+                    </head>
+                    <body>
+                      <nav class="navbar navbar-static-top navbar-default">
+                        <div class="container">
+                          <!-- Brand and toggle get grouped for better mobile display -->
+                          <div class="navbar-header">
+                            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse-1" aria-expanded="false">
+                              <span class="sr-only">Toggle navigation</span>
+                              <span class="icon-bar"></span>
+                              <span class="icon-bar"></span>
+                              <span class="icon-bar"></span>
+                            </button>
+                            <a class="navbar-brand" href="/"><img src="/asset/3137d8fd56/logo.svg" alt="openQA"></a>
+                          </div>
+                          <!-- Collect the nav links, forms, and other content for toggling -->
+                          <div class="collapse navbar-collapse" id="navbar-collapse-1">
+                            <ul class="nav navbar-nav">
+
+                              <li>
+                                <a href="/tests">All Tests</a>
+                              </li>
+
+                              <li class="dropdown">
+                                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Job Groups<span class="caret"></span></a>
+                                <ul class="dropdown-menu">
 
                                   <li>
-                                      <a href="/group_overview/25">Acceptance: openSUSE Tumbleweed  1.Gnome</a>
+                                    <a href="/group_overview/25">Acceptance: openSUSE Tumbleweed  1.Gnome</a>
                                   </li>
-                          </ul>
-                      </li>
-                  </ul>
-                  <ul class="nav navbar-nav navbar-right">
-                          <li id="user-action">
-                              <a href="/login">Login</a>
-                          </li>
-                  </ul>
-              </div><!-- /.navbar-collapse -->
-          </div>
-      </nav>
-      <div class="container" id="content">
-
-
-<div>
-    <h2>Test result overview</h2>
-    <div id="summary" class="panel panel-danger">
-        <div class="panel-heading">
-            Overall Summary of
-                <b><a href="/group_overview/25">Acceptance: openSUSE Tumbleweed  1.Gnome</a></b>
-            build 2137
-        </div>
-        <div class="panel-body">
-            Passed: <span class="badge">174</span>
-
-                Incomplete:
-                <span class="badge">1</span>
-                Soft Failure:
-                <span class="badge">11</span>
-            Failed: <span class="badge">25</span>
-
-        </div>
-    </div>
-    <div class="panel panel-default" id="filter-panel">
-        <div class="panel-heading"><strong>Filter</strong> <span>no filter present, click to toggle filter form<span></div>
-        <div class="panel-body">
-            <form action="#" type="get" id="filter-form">
-                <div class="form-group" id="filter-results">
-                    <strong>Result</strong>
-                        <label><input value="none" name="result" type="checkbox" id="filter-none"> None</label>
-                        <label><input value="passed" name="result" type="checkbox" id="filter-passed"> Passed</label>
-                        <label><input value="softfailed" name="result" type="checkbox" id="filter-softfailed"> Softfailed</label>
-                        <label><input value="failed" name="result" type="checkbox" id="filter-failed"> Failed</label>
-                        <label><input value="incomplete" name="result" type="checkbox" id="filter-incomplete"> Incomplete</label>
-                        <label><input value="skipped" name="result" type="checkbox" id="filter-skipped"> Skipped</label>
-                        <label><input value="obsoleted" name="result" type="checkbox" id="filter-obsoleted"> Obsoleted</label>
-                        <label><input value="parallel_failed" name="result" type="checkbox" id="filter-parallel_failed"> Parallel failed</label>
-                        <label><input value="parallel_restarted" name="result" type="checkbox" id="filter-parallel_restarted"> Parallel restarted</label>
-                        <label><input value="user_cancelled" name="result" type="checkbox" id="filter-user_cancelled"> User cancelled</label>
-                        <label><input value="user_restarted" name="result" type="checkbox" id="filter-user_restarted"> User restarted</label>
-                </div>
-                <div class="form-group" id="filter-states">
-                    <strong>State</strong>
-                        <label><input value="scheduled" name="state" type="checkbox" id="filter-scheduled"> Scheduled</label>
-                        <label><input value="running" name="state" type="checkbox" id="filter-running"> Running</label>
-                        <label><input value="cancelled" name="state" type="checkbox" id="filter-cancelled"> Cancelled</label>
-                        <label><input value="waiting" name="state" type="checkbox" id="filter-waiting"> Waiting</label>
-                        <label><input value="done" name="state" type="checkbox" id="filter-done"> Done</label>
-                        <label><input value="uploading" name="state" type="checkbox" id="filter-uploading"> Uploading</label>
-                </div>
-                <div class="form-group">
-                    <strong>Architecture</strong>
-                    <input type="text" class="form-control" name="arch" placeholder="any" id="filter-arch">
-                </div>
-                <div class="form-group">
-                    <strong>Misc</strong>
-                    <label><input value="1" name="todo" type="checkbox" id="filter-todo"> TODO</label>
-                </div>
-                <button type="submit" class="btn btn-default">Apply</button>
-            </form>
-        </div>
-    </div>
-        <h3>Flavor: Gnome-DVD</h3>
-        <table id="results_Gnome-DVD" class="overview table table-striped table-hover">
-            <thead>
-                <tr id="flavors">
-                    <th>Test</th>
-                        <th id="flavor_Gnome-DVD_arch_aarch64">aarch64</th>
-                        <th id="flavor_Gnome-DVD_arch_arm">arm</th>
-                        <th id="flavor_Gnome-DVD_arch_i586">i586</th>
-                        <th id="flavor_Gnome-DVD_arch_x86_64">x86_64</th>
-                </tr>
-            </thead>
-            <tbody>
-                    <tr>
-                        <td class="name">RAID0</td>
+                                </ul>
+                              </li>
+                            </ul>
+                            <ul class="nav navbar-nav navbar-right">
+                              <li id="user-action">
+                                <a href="/login">Login</a>
+                              </li>
+                            </ul>
+                          </div><!-- /.navbar-collapse -->
+                        </div>
+                      </nav>
+                      <div class="container" id="content">
+
+
+                        <div>
+                          <h2>Test result overview</h2>
+                          <div id="summary" class="panel panel-danger">
+                            <div class="panel-heading">
+                              Overall Summary of
+                              <b><a href="/group_overview/25">Acceptance: openSUSE Tumbleweed  1.Gnome</a></b>
+                              build 2137
+                            </div>
+                            <div class="panel-body">
+                              Passed: <span class="badge">174</span>
+
+                              Incomplete:
+                              <span class="badge">1</span>
+                              Soft Failure:
+                              <span class="badge">11</span>
+                              Failed: <span class="badge">25</span>
+
+                            </div>
+                          </div>
+                          <div class="panel panel-default" id="filter-panel">
+                            <div class="panel-heading"><strong>Filter</strong> <span>no filter present, click to toggle filter form<span></div>
+                            <div class="panel-body">
+                              <form action="#" type="get" id="filter-form">
+                                <div class="form-group" id="filter-results">
+                                  <strong>Result</strong>
+                                  <label><input value="none" name="result" type="checkbox" id="filter-none"> None</label>
+                                  <label><input value="passed" name="result" type="checkbox" id="filter-passed"> Passed</label>
+                                  <label><input value="softfailed" name="result" type="checkbox" id="filter-softfailed"> Softfailed</label>
+                                  <label><input value="failed" name="result" type="checkbox" id="filter-failed"> Failed</label>
+                                  <label><input value="incomplete" name="result" type="checkbox" id="filter-incomplete"> Incomplete</label>
+                                  <label><input value="skipped" name="result" type="checkbox" id="filter-skipped"> Skipped</label>
+                                  <label><input value="obsoleted" name="result" type="checkbox" id="filter-obsoleted"> Obsoleted</label>
+                                  <label><input value="parallel_failed" name="result" type="checkbox" id="filter-parallel_failed"> Parallel failed</label>
+                                  <label><input value="parallel_restarted" name="result" type="checkbox" id="filter-parallel_restarted"> Parallel restarted</label>
+                                  <label><input value="user_cancelled" name="result" type="checkbox" id="filter-user_cancelled"> User cancelled</label>
+                                  <label><input value="user_restarted" name="result" type="checkbox" id="filter-user_restarted"> User restarted</label>
+                                </div>
+                                <div class="form-group" id="filter-states">
+                                  <strong>State</strong>
+                                  <label><input value="scheduled" name="state" type="checkbox" id="filter-scheduled"> Scheduled</label>
+                                  <label><input value="running" name="state" type="checkbox" id="filter-running"> Running</label>
+                                  <label><input value="cancelled" name="state" type="checkbox" id="filter-cancelled"> Cancelled</label>
+                                  <label><input value="waiting" name="state" type="checkbox" id="filter-waiting"> Waiting</label>
+                                  <label><input value="done" name="state" type="checkbox" id="filter-done"> Done</label>
+                                  <label><input value="uploading" name="state" type="checkbox" id="filter-uploading"> Uploading</label>
+                                </div>
+                                <div class="form-group">
+                                  <strong>Architecture</strong>
+                                  <input type="text" class="form-control" name="arch" placeholder="any" id="filter-arch">
+                                  </div>
+                                  <div class="form-group">
+                                    <strong>Misc</strong>
+                                    <label><input value="1" name="todo" type="checkbox" id="filter-todo"> TODO</label>
+                                  </div>
+                                  <button type="submit" class="btn btn-default">Apply</button>
+                                </form>
+                              </div>
+                            </div>
+                            <h3>Flavor: Gnome-DVD</h3>
+                            <table id="results_Gnome-DVD" class="overview table table-striped table-hover">
+                              <thead>
+                                <tr id="flavors">
+                                  <th>Test</th>
+                                  <th id="flavor_Gnome-DVD_arch_aarch64">aarch64</th>
+                                  <th id="flavor_Gnome-DVD_arch_arm">arm</th>
+                                  <th id="flavor_Gnome-DVD_arch_i586">i586</th>
+                                  <th id="flavor_Gnome-DVD_arch_x86_64">x86_64</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                <tr>
+                                  <td class="name">RAID0</td>
 
-                            <td id="res_Gnome-DVD_aarch64_RAID0">
+                                  <td id="res_Gnome-DVD_aarch64_RAID0">
 
-             <span id="res-584870">
-                 <a href="/tests/584870">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584870">
+                                      <a href="/tests/584870">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_RAID0">
+                                  <td id="res_Gnome-DVD_arm_RAID0">
 
-             <span id="res-582638">
-                 <a href="/tests/582638">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-582638">
+                                      <a href="/tests/582638">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_RAID0">
+                                  <td id="res_Gnome-DVD_x86_64_RAID0">
 
-             <span id="res-584454">
-                 <a href="/tests/584454">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584454">
+                                      <a href="/tests/584454">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">RAID1</td>
+                                </tr>
+                                <tr>
+                                  <td class="name">RAID1</td>
 
-                            <td id="res_Gnome-DVD_aarch64_RAID1">
+                                  <td id="res_Gnome-DVD_aarch64_RAID1">
 
-             <span id="res-585022">
-                 <a href="/tests/585022">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-585022">
+                                      <a href="/tests/585022">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_RAID1">
+                                  <td id="res_Gnome-DVD_arm_RAID1">
 
-             <span id="res-582639">
-                 <a href="/tests/582639">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-582639">
+                                      <a href="/tests/582639">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_RAID1">
+                                  <td id="res_Gnome-DVD_x86_64_RAID1">
 
-             <span id="res-584455">
-                 <a href="/tests/584455">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584455">
+                                      <a href="/tests/584455">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">RAID10</td>
+                                </tr>
+                                <tr>
+                                  <td class="name">RAID10</td>
 
-                            <td id="res_Gnome-DVD_aarch64_RAID10">
+                                  <td id="res_Gnome-DVD_aarch64_RAID10">
 
-             <span id="res-585021">
-                 <a href="/tests/585021">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-585021">
+                                      <a href="/tests/585021">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_RAID10">
+                                  <td id="res_Gnome-DVD_arm_RAID10">
 
-             <span id="res-582640">
-                 <a href="/tests/582640">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-582640">
+                                      <a href="/tests/582640">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_RAID10">
+                                  <td id="res_Gnome-DVD_x86_64_RAID10">
 
-             <span id="res-584494">
-                 <a href="/tests/584494">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584494">
+                                      <a href="/tests/584494">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">RAID5</td>
+                                </tr>
+                                <tr>
+                                  <td class="name">RAID5</td>
 
-                            <td id="res_Gnome-DVD_aarch64_RAID5">
+                                  <td id="res_Gnome-DVD_aarch64_RAID5">
 
-             <span id="res-584867">
-                 <a href="/tests/584867">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584867">
+                                      <a href="/tests/584867">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_RAID5">
+                                  <td id="res_Gnome-DVD_arm_RAID5">
 
-             <span id="res-582657">
-                 <a href="/tests/582657">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-582657">
+                                      <a href="/tests/582657">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_RAID5">
+                                  <td id="res_Gnome-DVD_x86_64_RAID5">
 
-             <span id="res-584495">
-                 <a href="/tests/584495">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584495">
+                                      <a href="/tests/584495">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">RAID6</td>
+                                </tr>
+                                <tr>
+                                  <td class="name">RAID6</td>
 
-                            <td id="res_Gnome-DVD_aarch64_RAID6">
+                                  <td id="res_Gnome-DVD_aarch64_RAID6">
 
-             <span id="res-586973">
-                 <a href="/tests/586973">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-586973">
+                                      <a href="/tests/586973">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_RAID6">
+                                  <td id="res_Gnome-DVD_arm_RAID6">
 
-             <span id="res-582668">
-                 <a href="/tests/582668">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-582668">
+                                      <a href="/tests/582668">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_RAID6">
+                                  <td id="res_Gnome-DVD_x86_64_RAID6">
 
-             <span id="res-584550">
-                 <a href="/tests/584550">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584550">
+                                      <a href="/tests/584550">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">USBinstall</td>
+                                </tr>
+                                <tr>
+                                  <td class="name">USBinstall</td>
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_USBinstall">
+                                  <td id="res_Gnome-DVD_x86_64_USBinstall">
 
-             <span id="res-584931">
-                 <a href="/tests/584931">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584931">
+                                      <a href="/tests/584931">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">USBinstall@uefi</td>
+                                </tr>
+                                <tr>
+                                  <td class="name">USBinstall@uefi</td>
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                                <td>-</td>
+                                  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_USBinstall@uefi">
+                                  <td id="res_Gnome-DVD_x86_64_USBinstall@uefi">
 
-             <span id="res-584935">
-                 <a href="/tests/584935">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                    <span id="res-584935">
+                                      <a href="/tests/584935">
+                                        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                      </a>
+                                    </span>
 
 
 
-</td>
+                                  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">allpatterns</td>
+                                </tr>
+                                <tr>
+                                  <td class="name">allpatterns</td>
 
-                            <td id="res_Gnome-DVD_aarch64_allpatterns">
+                                  <td id="res_Gnome-DVD_aarch64_allpatterns">
 
-             <span id="res-586971">
-                 <a href="/tests/586971">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+                                    <span id="res-586971">
+                                      <a href="/tests/586971">
+                                        <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+                                      </a>
+                                    </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>empty-yast2-sw_single-20141115</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/586971#step/yast2_i/8">yast2_i</a>
-    </span>
+                                    <span title='<p>Failed needles:</p><ul><li>empty-yast2-sw_single-20141115</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                                    <a href="/tests/586971#step/yast2_i/8">yast2_i</a>
+                                  </span>
 
-             <span id="bug-586971">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=990384">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#990384"></i>
-        </a>
-    </span>
+                                  <span id="bug-586971">
+                                    <a href="https://bugzilla.suse.com/show_bug.cgi?id=990384">
+                                      <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#990384"></i>
+                                    </a>
+                                  </span>
 
-</td>
+                                </td>
 
 
-                            <td id="res_Gnome-DVD_arm_allpatterns">
+                                <td id="res_Gnome-DVD_arm_allpatterns">
 
-             <span id="res-584950">
-                 <a href="/tests/584950">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                  <span id="res-584950">
+                                    <a href="/tests/584950">
+                                      <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                    </a>
+                                  </span>
 
 
 
-</td>
+                                </td>
 
 
-                            <td id="res_Gnome-DVD_i586_allpatterns">
+                                <td id="res_Gnome-DVD_i586_allpatterns">
 
-             <span id="res-584949">
-                 <a href="/tests/584949">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                                  <span id="res-584949">
+                                    <a href="/tests/584949">
+                                      <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                                    </a>
+                                  </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>reboot-auth-20140701</li><li>reboot-auth-20160503</li><li>reboot-auth-20160505</li><li>reboot-auth-20160713</li><li>reboot-auth-NOICON-20150515</li><li>reboot_gnome-reboot-auth-i586-20160414</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584949#step/reboot_gnome/6">reboot_gnome</a>
-    </span>
+                                  <span title='<p>Failed needles:</p><ul><li>reboot-auth-20140701</li><li>reboot-auth-20160503</li><li>reboot-auth-20160505</li><li>reboot-auth-20160713</li><li>reboot-auth-NOICON-20150515</li><li>reboot_gnome-reboot-auth-i586-20160414</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                                  <a href="/tests/584949#step/reboot_gnome/6">reboot_gnome</a>
+                                </span>
 
-             <span id="bug-584949">
-        <a href="https://progress.opensuse.org/issues/12758">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12758"></i>
-        </a>
-    </span>
+                                <span id="bug-584949">
+                                  <a href="https://progress.opensuse.org/issues/12758">
+                                    <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12758"></i>
+                                  </a>
+                                </span>
 
-</td>
+                              </td>
 
 
-                            <td id="res_Gnome-DVD_x86_64_allpatterns">
+                              <td id="res_Gnome-DVD_x86_64_allpatterns">
 
-             <span id="res-584932">
-                 <a href="/tests/584932">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584932">
+                                  <a href="/tests/584932">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="allpatterns@i586--l2">allpatterns@i586--vswi ...</span></td>
+                            </tr>
+                            <tr>
+                              <td class="name"><span title="allpatterns@i586--l2">allpatterns@i586--vswi ...</span></td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_allpatterns@i586--l2">
+                              <td id="res_Gnome-DVD_i586_allpatterns@i586--l2">
 
-             <span id="res-582682">
-                 <a href="/tests/582682">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582682">
+                                  <a href="/tests/582682">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">autoupgrade_13.1</td>
+                              <td>-</td>
+                            </tr>
+                            <tr>
+                              <td class="name">autoupgrade_13.1</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_autoupgrade_13.1">
+                              <td id="res_Gnome-DVD_x86_64_autoupgrade_13.1">
 
-             <span id="res-584934">
-                 <a href="/tests/584934">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584934">
+                                  <a href="/tests/584934">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">autoupgrade_13.1_local</td>
+                            </tr>
+                            <tr>
+                              <td class="name">autoupgrade_13.1_local</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_autoupgrade_13.1_local">
+                              <td id="res_Gnome-DVD_x86_64_autoupgrade_13.1_local">
 
-             <span id="res-584933">
-                 <a href="/tests/584933">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584933">
+                                  <a href="/tests/584933">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">autoupgrade_13.2_ga</td>
+                            </tr>
+                            <tr>
+                              <td class="name">autoupgrade_13.2_ga</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_autoupgrade_13.2_ga">
+                              <td id="res_Gnome-DVD_x86_64_autoupgrade_13.2_ga">
 
-             <span id="res-584939">
-                 <a href="/tests/584939">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584939">
+                                  <a href="/tests/584939">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">autoupgrade_13.2</td>
+                            </tr>
+                            <tr>
+                              <td class="name">autoupgrade_13.2</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_autoupgrade_13.2">
+                              <td id="res_Gnome-DVD_x86_64_autoupgrade_13.2">
 
-             <span id="res-584936">
-                 <a href="/tests/584936">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584936">
+                                  <a href="/tests/584936">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">autoyast_eula</td>
+                            </tr>
+                            <tr>
+                              <td class="name">autoyast_eula</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_autoyast_eula">
+                              <td id="res_Gnome-DVD_x86_64_autoyast_eula">
 
-             <span id="res-584464">
-                 <a href="/tests/584464">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584464">
+                                  <a href="/tests/584464">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">autoyast_13.2_ext4</td>
+                            </tr>
+                            <tr>
+                              <td class="name">autoyast_13.2_ext4</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_autoyast_13.2_ext4">
+                              <td id="res_Gnome-DVD_x86_64_autoyast_13.2_ext4">
 
-             <span id="res-584962">
-                 <a href="/tests/584962">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584962">
+                                  <a href="/tests/584962">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">autoyast_13.2_gnome</td>
+                            </tr>
+                            <tr>
+                              <td class="name">autoyast_13.2_gnome</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_autoyast_13.2_gnome">
+                              <td id="res_Gnome-DVD_x86_64_autoyast_13.2_gnome">
 
-             <span id="res-584941">
-                 <a href="/tests/584941">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584941">
+                                  <a href="/tests/584941">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">boot_to_snapshot</td>
+                            </tr>
+                            <tr>
+                              <td class="name">boot_to_snapshot</td>
 
-                            <td id="res_Gnome-DVD_aarch64_boot_to_snapshot">
+                              <td id="res_Gnome-DVD_aarch64_boot_to_snapshot">
 
-             <span id="res-584790">
-                 <a href="/tests/584790">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584790">
+                                  <a href="/tests/584790">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                            <td id="res_Gnome-DVD_arm_boot_to_snapshot">
+                              <td id="res_Gnome-DVD_arm_boot_to_snapshot">
 
-             <span id="res-582585">
-                 <a href="/tests/582585">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+                                <span id="res-582585">
+                                  <a href="/tests/582585">
+                                    <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_boot_to_snapshot">
+                              <td id="res_Gnome-DVD_x86_64_boot_to_snapshot">
 
-             <span id="res-584349">
-                 <a href="/tests/584349">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584349">
+                                  <a href="/tests/584349">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs</td>
+                            </tr>
+                            <tr>
+                              <td class="name">btrfs</td>
 
-                            <td id="res_Gnome-DVD_aarch64_btrfs">
+                              <td id="res_Gnome-DVD_aarch64_btrfs">
 
-             <span id="res-584791">
-                 <a href="/tests/584791">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584791">
+                                  <a href="/tests/584791">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                            <td id="res_Gnome-DVD_arm_btrfs">
+                              <td id="res_Gnome-DVD_arm_btrfs">
 
-             <span id="res-582586">
-                 <a href="/tests/582586">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582586">
+                                  <a href="/tests/582586">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                            <td id="res_Gnome-DVD_i586_btrfs">
+                              <td id="res_Gnome-DVD_i586_btrfs">
 
-             <span id="res-582678">
-                 <a href="/tests/582678">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582678">
+                                  <a href="/tests/582678">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                            <td id="res_Gnome-DVD_x86_64_btrfs">
+                              <td id="res_Gnome-DVD_x86_64_btrfs">
 
-             <span id="res-584350">
-                 <a href="/tests/584350">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584350">
+                                  <a href="/tests/584350">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--ctc</td>
+                            </tr>
+                            <tr>
+                              <td class="name">btrfs@i586--ctc</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_btrfs@i586--ctc">
+                              <td id="res_Gnome-DVD_i586_btrfs@i586--ctc">
 
-             <span id="res-582672">
-                 <a href="/tests/582672">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582672">
+                                  <a href="/tests/582672">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l2</td>
+                              <td>-</td>
+                            </tr>
+                            <tr>
+                              <td class="name">btrfs@i586--l2</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_btrfs@i586--l2">
+                              <td id="res_Gnome-DVD_i586_btrfs@i586--l2">
 
-             <span id="res-582684">
-                 <a href="/tests/582684">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582684">
+                                  <a href="/tests/582684">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l3</td>
+                              <td>-</td>
+                            </tr>
+                            <tr>
+                              <td class="name">btrfs@i586--l3</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_btrfs@i586--l3">
+                              <td id="res_Gnome-DVD_i586_btrfs@i586--l3">
 
-             <span id="res-582685">
-                 <a href="/tests/582685">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582685">
+                                  <a href="/tests/582685">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l2</td>
+                              <td>-</td>
+                            </tr>
+                            <tr>
+                              <td class="name">btrfs@i586--l2</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_btrfs@i586--l2">
+                              <td id="res_Gnome-DVD_i586_btrfs@i586--l2">
 
-             <span id="res-582686">
-                 <a href="/tests/582686">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582686">
+                                  <a href="/tests/582686">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">btrfs@i586--l3</td>
+                              <td>-</td>
+                            </tr>
+                            <tr>
+                              <td class="name">btrfs@i586--l3</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_btrfs@i586--l3">
+                              <td id="res_Gnome-DVD_i586_btrfs@i586--l3">
 
-             <span id="res-582679">
-                 <a href="/tests/582679">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-582679">
+                                  <a href="/tests/582679">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">cryptlvm</td>
+                              <td>-</td>
+                            </tr>
+                            <tr>
+                              <td class="name">cryptlvm</td>
 
-                            <td id="res_Gnome-DVD_aarch64_cryptlvm">
+                              <td id="res_Gnome-DVD_aarch64_cryptlvm">
 
-             <span id="res-585632">
-                 <a href="/tests/585632">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-585632">
+                                  <a href="/tests/585632">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                            <td id="res_Gnome-DVD_arm_cryptlvm">
+                              <td id="res_Gnome-DVD_arm_cryptlvm">
 
-             <span id="res-585962">
-                 <a href="/tests/585962">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+                                <span id="res-585962">
+                                  <a href="/tests/585962">
+                                    <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
 
-                                <td>-</td>
+                              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_cryptlvm">
+                              <td id="res_Gnome-DVD_x86_64_cryptlvm">
 
-             <span id="res-584948">
-                 <a href="/tests/584948">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                                <span id="res-584948">
+                                  <a href="/tests/584948">
+                                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                                  </a>
+                                </span>
 
 
 
-</td>
+                              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">cryptlvm+activate_existing</td>
+                            </tr>
+                            <tr>
+                              <td class="name">cryptlvm+activate_existing</td>
 
-                            <td id="res_Gnome-DVD_aarch64_cryptlvm+activate_existing">
+                              <td id="res_Gnome-DVD_aarch64_cryptlvm+activate_existing">
 
-             <span id="res-585630">
-                 <a href="/tests/585630">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                                <span id="res-585630">
+                                  <a href="/tests/585630">
+                                    <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                                  </a>
+                                </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/585630#step/boot_encrypt/7">boot_encrypt</a>
-    </span>
+                                <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                                <a href="/tests/585630#step/boot_encrypt/7">boot_encrypt</a>
+                              </span>
 
-             <span id="bug-585630">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
-        </a>
-    </span>
+                              <span id="bug-585630">
+                                <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
+                                  <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
+                                </a>
+                              </span>
 
-</td>
+                            </td>
 
 
                             <td id="res_Gnome-DVD_arm_cryptlvm+activate_existing">
 
-             <span id="res-585625">
-                 <a href="/tests/585625">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                              <span id="res-585625">
+                                <a href="/tests/585625">
+                                  <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                                </a>
+                              </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>boot_encrypt_ofw-20150714</li><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/585625#step/grub_test/10">grub_test</a>
-    </span>
+                              <span title='<p>Failed needles:</p><ul><li>boot_encrypt_ofw-20150714</li><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                              <a href="/tests/585625#step/grub_test/10">grub_test</a>
+                            </span>
 
-             <span id="bug-585625">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
-        </a>
-    </span>
+                            <span id="bug-585625">
+                              <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
+                                <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
+                              </a>
+                            </span>
 
-</td>
+                          </td>
 
 
-                                <td>-</td>
+                          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_cryptlvm+activate_existing">
+                          <td id="res_Gnome-DVD_x86_64_cryptlvm+activate_existing">
 
-             <span id="res-584947">
-                 <a href="/tests/584947">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                            <span id="res-584947">
+                              <a href="/tests/584947">
+                                <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                              </a>
+                            </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584947#step/boot_encrypt/4">boot_encrypt</a>
-    </span>
+                            <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                            <a href="/tests/584947#step/boot_encrypt/4">boot_encrypt</a>
+                          </span>
 
-             <span id="bug-584947">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
-        </a>
-    </span>
+                          <span id="bug-584947">
+                            <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
+                              <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
+                            </a>
+                          </span>
 
-</td>
+                        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="cryptlvm+activate_existing+force_recompute">cryptlvm+activate_existing ...</span></td>
+                      </tr>
+                      <tr>
+                        <td class="name"><span title="cryptlvm+activate_existing+force_recompute">cryptlvm+activate_existing+force_recompute</span></td>
 
-                            <td id="res_Gnome-DVD_aarch64_cryptlvm+activate_existing+force_recompute">
+                        <td id="res_Gnome-DVD_aarch64_cryptlvm+activate_existing+force_recompute">
 
-             <span id="res-587009">
-                 <a href="/tests/587009">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+                          <span id="res-587009">
+                            <a href="/tests/587009">
+                              <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+                            </a>
+                          </span>
 
 
-             <span id="bug-587009">
-        <a href="https://progress.opensuse.org/issues/12782">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12782"></i>
-        </a>
-    </span>
+                          <span id="bug-587009">
+                            <a href="https://progress.opensuse.org/issues/12782">
+                              <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12782"></i>
+                            </a>
+                          </span>
 
-</td>
+                        </td>
 
 
-                            <td id="res_Gnome-DVD_arm_cryptlvm+activate_existing+force_recompute">
+                        <td id="res_Gnome-DVD_arm_cryptlvm+activate_existing+force_recompute">
 
-             <span id="res-585961">
-                 <a href="/tests/585961">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                          <span id="res-585961">
+                            <a href="/tests/585961">
+                              <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                            </a>
+                          </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>partition-nocrypt-lvm-new-summary-20160429</li><li>partitioning_lvm-partition-lvm-new-summary-20160308</li><li>partitioning_lvm-partition-nocrypt-lvm-new-summary-20160308</li><li>partitioning_lvm-partitioning-encrypt-activated-existing-20160802</li><li>partitioning_lvm-partitioning-encrypt-broke-existing-20160812</li><li>partitioning_lvm-partitioning-encrypt-broke-existing-20160823</li><li>partitioning_lvm-partitioning-encrypt-broke-existing-20160907</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/585961#step/partitioning_lvm/8">partitioning_lvm</a>
-    </span>
+                          <span title='<p>Failed needles:</p><ul><li>partition-nocrypt-lvm-new-summary-20160429</li><li>partitioning_lvm-partition-lvm-new-summary-20160308</li><li>partitioning_lvm-partition-nocrypt-lvm-new-summary-20160308</li><li>partitioning_lvm-partitioning-encrypt-activated-existing-20160802</li><li>partitioning_lvm-partitioning-encrypt-broke-existing-20160812</li><li>partitioning_lvm-partitioning-encrypt-broke-existing-20160823</li><li>partitioning_lvm-partitioning-encrypt-broke-existing-20160907</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                          <a href="/tests/585961#step/partitioning_lvm/8">partitioning_lvm</a>
+                        </span>
 
-             <span id="bug-585961">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
-        </a>
-    </span>
+                        <span id="bug-585961">
+                          <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
+                            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
+                          </a>
+                        </span>
 
-</td>
+                      </td>
 
 
-                                <td>-</td>
+                      <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_cryptlvm+activate_existing+force_recompute">
+                      <td id="res_Gnome-DVD_x86_64_cryptlvm+activate_existing+force_recompute">
 
-             <span id="res-584944">
-                 <a href="/tests/584944">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                        <span id="res-584944">
+                          <a href="/tests/584944">
+                            <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                          </a>
+                        </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>inst-packageinstallationstarted-20141204</li><li>inst-packageinstallationstarted-20160429</li><li>inst-packageinstallationstarted-NOSLIDESHOW-20151113</li><li>inst-packageinstallationstarted-NOSLIDESHOW-20160501</li><li>installation-details-view-20160501</li><li>installation-details-view-20160504</li><li>installation-details-view-20160506</li><li>installation-details-view-NOSLIDESHOW-bsc982138-20160616</li><li>installation-details-view-bsc982138-20160531</li><li>installation-details-view-bsc982138-20160705</li><li>installation-details-view-bsc982138-20160706</li><li>installation-details-view-bsc982138-bsc987604-20160705</li><li>installation-details-view-bsc982138-bsc987604-20160706</li><li>installation-details-view-bsc987604-20160705</li><li>installation-details-view-bsc987791-20160706</li><li>installation-details-view-bsc987791-alt2-20160706</li><li>start_install-installation-details-view-20160503</li><li>start_install-installation-details-view-20160506</li><li>start_install-installation-details-view-20160706</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584944#step/start_install/15">start_install</a>
-    </span>
+                        <span title='<p>Failed needles:</p><ul><li>inst-packageinstallationstarted-20141204</li><li>inst-packageinstallationstarted-20160429</li><li>inst-packageinstallationstarted-NOSLIDESHOW-20151113</li><li>inst-packageinstallationstarted-NOSLIDESHOW-20160501</li><li>installation-details-view-20160501</li><li>installation-details-view-20160504</li><li>installation-details-view-20160506</li><li>installation-details-view-NOSLIDESHOW-bsc982138-20160616</li><li>installation-details-view-bsc982138-20160531</li><li>installation-details-view-bsc982138-20160705</li><li>installation-details-view-bsc982138-20160706</li><li>installation-details-view-bsc982138-bsc987604-20160705</li><li>installation-details-view-bsc982138-bsc987604-20160706</li><li>installation-details-view-bsc987604-20160705</li><li>installation-details-view-bsc987791-20160706</li><li>installation-details-view-bsc987791-alt2-20160706</li><li>start_install-installation-details-view-20160503</li><li>start_install-installation-details-view-20160506</li><li>start_install-installation-details-view-20160706</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                        <a href="/tests/584944#step/start_install/15">start_install</a>
+                      </span>
 
-             <span id="bug-584944">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=996007">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#996007"></i>
-        </a>
-    </span>
+                      <span id="bug-584944">
+                        <a href="https://bugzilla.suse.com/show_bug.cgi?id=996007">
+                          <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#996007"></i>
+                        </a>
+                      </span>
 
-</td>
+                    </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="cryptlvm+activate_existing+import_users">cryptlvm+activate_existing ...</span></td>
+                  </tr>
+                  <tr>
+                    <td class="name"><span title="cryptlvm+activate_existing+import_users">cryptlvm+activate_existing+force_recompute</span></td>
 
-                            <td id="res_Gnome-DVD_aarch64_cryptlvm+activate_existing+import_users">
+                    <td id="res_Gnome-DVD_aarch64_cryptlvm+activate_existing+import_users">
 
-             <span id="res-585629">
-                 <a href="/tests/585629">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                      <span id="res-585629">
+                        <a href="/tests/585629">
+                          <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                        </a>
+                      </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/585629#step/boot_encrypt/6">boot_encrypt</a>
-    </span>
+                      <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                      <a href="/tests/585629#step/boot_encrypt/6">boot_encrypt</a>
+                    </span>
 
-             <span id="bug-585629">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
-        </a>
-    </span>
+                    <span id="bug-585629">
+                      <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
+                        <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
+                      </a>
+                    </span>
 
-</td>
+                  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_cryptlvm+activate_existing+import_users">
+                  <td id="res_Gnome-DVD_arm_cryptlvm+activate_existing+import_users">
 
-             <span id="res-585626">
-                 <a href="/tests/585626">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                    <span id="res-585626">
+                      <a href="/tests/585626">
+                        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                      </a>
+                    </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>boot_encrypt_ofw-20150714</li><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/585626#step/grub_test/10">grub_test</a>
-    </span>
+                    <span title='<p>Failed needles:</p><ul><li>boot_encrypt_ofw-20150714</li><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                    <a href="/tests/585626#step/grub_test/10">grub_test</a>
+                  </span>
 
-             <span id="bug-585626">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
-        </a>
-    </span>
+                  <span id="bug-585626">
+                    <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
+                      <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
+                    </a>
+                  </span>
 
-</td>
+                </td>
 
 
-                                <td>-</td>
+                <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_cryptlvm+activate_existing+import_users">
+                <td id="res_Gnome-DVD_x86_64_cryptlvm+activate_existing+import_users">
 
-             <span id="res-584946">
-                 <a href="/tests/584946">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                  <span id="res-584946">
+                    <a href="/tests/584946">
+                      <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                    </a>
+                  </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584946#step/boot_encrypt/6">boot_encrypt</a>
-    </span>
+                  <span title='<p>Failed needles:</p><ul><li>encrypted-disk-password-prompt-20141205</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                  <a href="/tests/584946#step/boot_encrypt/6">boot_encrypt</a>
+                </span>
 
-             <span id="bug-584946">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
-        </a>
-    </span>
+                <span id="bug-584946">
+                  <a href="https://bugzilla.suse.com/show_bug.cgi?id=993247">
+                    <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#993247"></i>
+                  </a>
+                </span>
 
-</td>
+              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">cryptlvm+cancel_existing</td>
+            </tr>
+            <tr>
+              <td class="name">cryptlvm+cancel_existing</td>
 
-                            <td id="res_Gnome-DVD_aarch64_cryptlvm+cancel_existing">
+              <td id="res_Gnome-DVD_aarch64_cryptlvm+cancel_existing">
 
-             <span id="res-585628">
-                 <a href="/tests/585628">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+                <span id="res-585628">
+                  <a href="/tests/585628">
+                    <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                            <td id="res_Gnome-DVD_arm_cryptlvm+cancel_existing">
+              <td id="res_Gnome-DVD_arm_cryptlvm+cancel_existing">
 
-             <span id="res-585960">
-                 <a href="/tests/585960">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-585960">
+                  <a href="/tests/585960">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                                <td>-</td>
+              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_cryptlvm+cancel_existing">
+              <td id="res_Gnome-DVD_x86_64_cryptlvm+cancel_existing">
 
-             <span id="res-584945">
-                 <a href="/tests/584945">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-584945">
+                  <a href="/tests/584945">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">cryptlvm_minimal_x</td>
+            </tr>
+            <tr>
+              <td class="name">cryptlvm_minimal_x</td>
 
-                            <td id="res_Gnome-DVD_aarch64_cryptlvm_minimal_x">
+              <td id="res_Gnome-DVD_aarch64_cryptlvm_minimal_x">
 
-             <span id="res-587015">
-                 <a href="/tests/587015">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-587015">
+                  <a href="/tests/587015">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                            <td id="res_Gnome-DVD_arm_cryptlvm_minimal_x">
+              <td id="res_Gnome-DVD_arm_cryptlvm_minimal_x">
 
-             <span id="res-584952">
-                 <a href="/tests/584952">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+                <span id="res-584952">
+                  <a href="/tests/584952">
+                    <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                                <td>-</td>
+              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_cryptlvm_minimal_x">
+              <td id="res_Gnome-DVD_x86_64_cryptlvm_minimal_x">
 
-             <span id="res-584937">
-                 <a href="/tests/584937">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-584937">
+                  <a href="/tests/584937">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">dud_gcc5</td>
+            </tr>
+            <tr>
+              <td class="name">dud_gcc5</td>
 
-                                <td>-</td>
+              <td>-</td>
 
-                                <td>-</td>
+              <td>-</td>
 
-                                <td>-</td>
+              <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_dud_gcc5">
+              <td id="res_Gnome-DVD_x86_64_dud_gcc5">
 
-             <span id="res-584826">
-                 <a href="/tests/584826">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-584826">
+                  <a href="/tests/584826">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">ext4</td>
+            </tr>
+            <tr>
+              <td class="name">ext4</td>
 
-                            <td id="res_Gnome-DVD_aarch64_ext4">
+              <td id="res_Gnome-DVD_aarch64_ext4">
 
-             <span id="res-584783">
-                 <a href="/tests/584783">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-584783">
+                  <a href="/tests/584783">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                            <td id="res_Gnome-DVD_arm_ext4">
+              <td id="res_Gnome-DVD_arm_ext4">
 
-             <span id="res-582606">
-                 <a href="/tests/582606">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-582606">
+                  <a href="/tests/582606">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                            <td id="res_Gnome-DVD_i586_ext4">
+              <td id="res_Gnome-DVD_i586_ext4">
 
-             <span id="res-582687">
-                 <a href="/tests/582687">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-582687">
+                  <a href="/tests/582687">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                            <td id="res_Gnome-DVD_x86_64_ext4">
+              <td id="res_Gnome-DVD_x86_64_ext4">
 
-             <span id="res-584396">
-                 <a href="/tests/584396">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-584396">
+                  <a href="/tests/584396">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">ext4@i586--l2</td>
+            </tr>
+            <tr>
+              <td class="name">ext4@i586--l2</td>
 
-                                <td>-</td>
+              <td>-</td>
 
-                                <td>-</td>
+              <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_ext4@i586--l2">
+              <td id="res_Gnome-DVD_i586_ext4@i586--l2">
 
-             <span id="res-582680">
-                 <a href="/tests/582680">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-582680">
+                  <a href="/tests/582680">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gnome</td>
+              <td>-</td>
+            </tr>
+            <tr>
+              <td class="name">gnome</td>
 
-                            <td id="res_Gnome-DVD_aarch64_gnome">
+              <td id="res_Gnome-DVD_aarch64_gnome">
 
-             <span id="res-584951">
-                 <a href="/tests/584951">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-584951">
+                  <a href="/tests/584951">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                            <td id="res_Gnome-DVD_arm_gnome">
+              <td id="res_Gnome-DVD_arm_gnome">
 
-             <span id="res-585770">
-                 <a href="/tests/585770">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+                <span id="res-585770">
+                  <a href="/tests/585770">
+                    <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                  </a>
+                </span>
 
 
 
-</td>
+              </td>
 
 
-                            <td id="res_Gnome-DVD_i586_gnome">
+              <td id="res_Gnome-DVD_i586_gnome">
 
-             <span id="res-584942">
-                 <a href="/tests/584942">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+                <span id="res-584942">
+                  <a href="/tests/584942">
+                    <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                  </a>
+                </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>reboot-auth-20140701</li><li>reboot-auth-20160503</li><li>reboot-auth-20160505</li><li>reboot-auth-20160713</li><li>reboot-auth-NOICON-20150515</li><li>reboot_gnome-reboot-auth-i586-20160414</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584942#step/reboot_gnome/6">reboot_gnome</a>
-    </span>
+                <span title='<p>Failed needles:</p><ul><li>reboot-auth-20140701</li><li>reboot-auth-20160503</li><li>reboot-auth-20160505</li><li>reboot-auth-20160713</li><li>reboot-auth-NOICON-20150515</li><li>reboot_gnome-reboot-auth-i586-20160414</li></ul>' data-toggle='tooltip' class="failedmodule" >
+                <a href="/tests/584942#step/reboot_gnome/6">reboot_gnome</a>
+              </span>
 
-             <span id="bug-584942">
-        <a href="https://progress.opensuse.org/issues/12758">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12758"></i>
-        </a>
-    </span>
+              <span id="bug-584942">
+                <a href="https://progress.opensuse.org/issues/12758">
+                  <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12758"></i>
+                </a>
+              </span>
 
-</td>
+            </td>
 
 
-                            <td id="res_Gnome-DVD_x86_64_gnome">
+            <td id="res_Gnome-DVD_x86_64_gnome">
 
-             <span id="res-584940">
-                 <a href="/tests/584940">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+              <span id="res-584940">
+                <a href="/tests/584940">
+                  <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+                </a>
+              </span>
 
 
 
-</td>
+            </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gnome+acpi</td>
+          </tr>
+          <tr>
+            <td class="name">gnome+acpi</td>
 
-                            <td id="res_Gnome-DVD_aarch64_gnome+acpi">
+            <td id="res_Gnome-DVD_aarch64_gnome+acpi">
 
-             <span id="res-584802">
-                 <a href="/tests/584802">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+              <span id="res-584802">
+                <a href="/tests/584802">
+                  <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                </a>
+              </span>
 
 
 
-</td>
+            </td>
 
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gnome+do_not_import_ssh_keys</td>
+            <td>-</td>
+          </tr>
+          <tr>
+            <td class="name">gnome+do_not_import_ssh_keys</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_gnome+do_not_import_ssh_keys">
+            <td id="res_Gnome-DVD_x86_64_gnome+do_not_import_ssh_keys">
 
-             <span id="res-584301">
-                 <a href="/tests/584301">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+              <span id="res-584301">
+                <a href="/tests/584301">
+                  <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                </a>
+              </span>
 
 
 
-</td>
+            </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gnome+import_ssh_keys</td>
+          </tr>
+          <tr>
+            <td class="name">gnome+import_ssh_keys</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_gnome+import_ssh_keys">
+            <td id="res_Gnome-DVD_x86_64_gnome+import_ssh_keys">
 
-             <span id="res-584302">
-                 <a href="/tests/584302">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+              <span id="res-584302">
+                <a href="/tests/584302">
+                  <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+                </a>
+              </span>
 
 
 
-</td>
+            </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gnome@64bit-ipmi</td>
+          </tr>
+          <tr>
+            <td class="name">gnome@64bit-ipmi</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                                <td>-</td>
+            <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_gnome@64bit-ipmi">
+            <td id="res_Gnome-DVD_x86_64_gnome@64bit-ipmi">
 
-             <span id="res-584958">
-                 <a href="/tests/584958">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+              <span id="res-584958">
+                <a href="/tests/584958">
+                  <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+                </a>
+              </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>yast2_lan-20160113</li><li>yast2_lan-hacluster-hostname-20150818</li><li>yast2_lan-ipmi-20160410</li><li>yast2_lan-ipmi-20160416</li><li>yast2_lan-other-font-20151214</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584958#step/yast2_lan/21">yast2_lan</a>
-    </span>
+              <span title='<p>Failed needles:</p><ul><li>yast2_lan-20160113</li><li>yast2_lan-hacluster-hostname-20150818</li><li>yast2_lan-ipmi-20160410</li><li>yast2_lan-ipmi-20160416</li><li>yast2_lan-other-font-20151214</li></ul>' data-toggle='tooltip' class="failedmodule" >
+              <a href="/tests/584958#step/yast2_lan/21">yast2_lan</a>
+            </span>
 
-             <span id="bug-584958">
-        <a href="https://progress.opensuse.org/issues/12982">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12982"></i>
-        </a>
-    </span>
+            <span id="bug-584958">
+              <a href="https://progress.opensuse.org/issues/12982">
+                <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12982"></i>
+              </a>
+            </span>
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gnome@64bit-smp</td>
+        </tr>
+        <tr>
+          <td class="name">gnome@64bit-smp</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_gnome@64bit-smp">
+          <td id="res_Gnome-DVD_x86_64_gnome@64bit-smp">
 
-             <span id="res-584943">
-                 <a href="/tests/584943">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+            <span id="res-584943">
+              <a href="/tests/584943">
+                <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gnome@arm-smp</td>
+        </tr>
+        <tr>
+          <td class="name">gnome@arm-smp</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_gnome@arm-smp">
+          <td id="res_Gnome-DVD_arm_gnome@arm-smp">
 
-             <span id="res-586976">
-                 <a href="/tests/586976">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-586976">
+              <a href="/tests/586976">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gnome@i586--l2</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td class="name">gnome@i586--l2</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_gnome@i586--l2">
+          <td id="res_Gnome-DVD_i586_gnome@i586--l2">
 
-             <span id="res-582674">
-                 <a href="/tests/582674">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-582674">
+              <a href="/tests/582674">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gnome@uefi</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td class="name">gnome@uefi</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_gnome@uefi">
+          <td id="res_Gnome-DVD_x86_64_gnome@uefi">
 
-             <span id="res-584963">
-                 <a href="/tests/584963">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584963">
+              <a href="/tests/584963">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gpt</td>
+        </tr>
+        <tr>
+          <td class="name">gpt</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_gpt">
+          <td id="res_Gnome-DVD_arm_gpt">
 
-             <span id="res-582608">
-                 <a href="/tests/582608">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-582608">
+              <a href="/tests/582608">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">installcheck</td>
+          <td>-</td>
+        </tr>
+        <tr>
+          <td class="name">installcheck</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_installcheck">
+          <td id="res_Gnome-DVD_arm_installcheck">
 
-             <span id="res-582574">
-                 <a href="/tests/582574">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-582574">
+              <a href="/tests/582574">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_installcheck">
+          <td id="res_Gnome-DVD_x86_64_installcheck">
 
-             <span id="res-584318">
-                 <a href="/tests/584318">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584318">
+              <a href="/tests/584318">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">iscsi_client</td>
+        </tr>
+        <tr>
+          <td class="name">iscsi_client</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_iscsi_client">
+          <td id="res_Gnome-DVD_x86_64_iscsi_client">
 
-             <span id="res-584551">
-                 <a href="/tests/584551">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584551">
+              <a href="/tests/584551">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">iscsi_ibft</td>
+        </tr>
+        <tr>
+          <td class="name">iscsi_ibft</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_iscsi_ibft">
+          <td id="res_Gnome-DVD_x86_64_iscsi_ibft">
 
-             <span id="res-586977">
-                 <a href="/tests/586977">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
+            <span id="res-586977">
+              <a href="/tests/586977">
+                <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">iscsi_server</td>
+        </tr>
+        <tr>
+          <td class="name">iscsi_server</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_iscsi_server">
+          <td id="res_Gnome-DVD_x86_64_iscsi_server">
 
-             <span id="res-584353">
-                 <a href="/tests/584353">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584353">
+              <a href="/tests/584353">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">lvm</td>
+        </tr>
+        <tr>
+          <td class="name">lvm</td>
 
-                            <td id="res_Gnome-DVD_aarch64_lvm">
+          <td id="res_Gnome-DVD_aarch64_lvm">
 
-             <span id="res-586972">
-                 <a href="/tests/586972">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-586972">
+              <a href="/tests/586972">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                            <td id="res_Gnome-DVD_arm_lvm">
+          <td id="res_Gnome-DVD_arm_lvm">
 
-             <span id="res-584978">
-                 <a href="/tests/584978">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584978">
+              <a href="/tests/584978">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_lvm">
+          <td id="res_Gnome-DVD_x86_64_lvm">
 
-             <span id="res-584964">
-                 <a href="/tests/584964">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584964">
+              <a href="/tests/584964">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">lvm+RAID1</td>
+        </tr>
+        <tr>
+          <td class="name">lvm+RAID1</td>
 
-                            <td id="res_Gnome-DVD_aarch64_lvm+RAID1">
+          <td id="res_Gnome-DVD_aarch64_lvm+RAID1">
 
-             <span id="res-584796">
-                 <a href="/tests/584796">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584796">
+              <a href="/tests/584796">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_lvm+RAID1">
+          <td id="res_Gnome-DVD_x86_64_lvm+RAID1">
 
-             <span id="res-584401">
-                 <a href="/tests/584401">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584401">
+              <a href="/tests/584401">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">mediacheck</td>
+        </tr>
+        <tr>
+          <td class="name">mediacheck</td>
 
-                            <td id="res_Gnome-DVD_aarch64_mediacheck">
+          <td id="res_Gnome-DVD_aarch64_mediacheck">
 
-             <span id="res-584884">
-                 <a href="/tests/584884">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584884">
+              <a href="/tests/584884">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                            <td id="res_Gnome-DVD_arm_mediacheck">
+          <td id="res_Gnome-DVD_arm_mediacheck">
 
-             <span id="res-582611">
-                 <a href="/tests/582611">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-582611">
+              <a href="/tests/582611">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_mediacheck">
+          <td id="res_Gnome-DVD_x86_64_mediacheck">
 
-             <span id="res-584402">
-                 <a href="/tests/584402">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584402">
+              <a href="/tests/584402">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">memtest</td>
+        </tr>
+        <tr>
+          <td class="name">memtest</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_memtest">
+          <td id="res_Gnome-DVD_x86_64_memtest">
 
-             <span id="res-584403">
-                 <a href="/tests/584403">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584403">
+              <a href="/tests/584403">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.1</td>
+        </tr>
+        <tr>
+          <td class="name">upgrade_offline_13.1</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1">
+          <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1">
 
-             <span id="res-584965">
-                 <a href="/tests/584965">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584965">
+              <a href="/tests/584965">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.1+gcc5">upgrade_offline_13.1_sp ...</span></td>
+        </tr>
+        <tr>
+          <td class="name"><span title="upgrade_offline_13.1+gcc5">upgrade_offline_13.1_sp ...</span></td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1+gcc5">
+          <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1+gcc5">
 
-             <span id="res-584966">
-                 <a href="/tests/584966">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584966">
+              <a href="/tests/584966">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.1_allpatterns">upgrade_offline_13.1_sp ...</span></td>
+        </tr>
+        <tr>
+          <td class="name"><span title="upgrade_offline_13.1_allpatterns">upgrade_offline_13.1_sp ...</span></td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1_allpatterns">
+          <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.1_allpatterns">
 
-             <span id="res-584967">
-                 <a href="/tests/584967">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584967">
+              <a href="/tests/584967">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.2</td>
+        </tr>
+        <tr>
+          <td class="name">upgrade_offline_13.2</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_upgrade_offline_13.2">
+          <td id="res_Gnome-DVD_arm_upgrade_offline_13.2">
 
-             <span id="res-584980">
-                 <a href="/tests/584980">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584980">
+              <a href="/tests/584980">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2">
+          <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2">
 
-             <span id="res-584969">
-                 <a href="/tests/584969">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584969">
+              <a href="/tests/584969">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2_allpatterns">upgrade_offline_13.2_al ...</span></td>
+        </tr>
+        <tr>
+          <td class="name"><span title="upgrade_offline_13.2_allpatterns">upgrade_offline_13.2_al ...</span></td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_upgrade_offline_13.2_allpatterns">
+          <td id="res_Gnome-DVD_arm_upgrade_offline_13.2_allpatterns">
 
-             <span id="res-584981">
-                 <a href="/tests/584981">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584981">
+              <a href="/tests/584981">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2_allpatterns">
+          <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2_allpatterns">
 
-             <span id="res-585019">
-                 <a href="/tests/585019">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-585019">
+              <a href="/tests/585019">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.2_gcc5</td>
+        </tr>
+        <tr>
+          <td class="name">upgrade_offline_13.2_gcc5</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2_gcc5">
+          <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2_gcc5">
 
-             <span id="res-584970">
-                 <a href="/tests/584970">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584970">
+              <a href="/tests/584970">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">upgrade_offline_13.2sp1</td>
+        </tr>
+        <tr>
+          <td class="name">upgrade_offline_13.2sp1</td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_upgrade_offline_13.2sp1">
+          <td id="res_Gnome-DVD_arm_upgrade_offline_13.2sp1">
 
-             <span id="res-584983">
-                 <a href="/tests/584983">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584983">
+              <a href="/tests/584983">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1">
+          <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1">
 
-             <span id="res-584977">
-                 <a href="/tests/584977">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+            <span id="res-584977">
+              <a href="/tests/584977">
+                <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+              </a>
+            </span>
 
 
 
-</td>
+          </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2sp1_allpatterns">upgrade_offline_13.2sp1 ...</span></td>
+        </tr>
+        <tr>
+          <td class="name"><span title="upgrade_offline_13.2sp1_allpatterns">upgrade_offline_13.2sp1 ...</span></td>
 
-                                <td>-</td>
+          <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_upgrade_offline_13.2sp1_allpatterns">
+          <td id="res_Gnome-DVD_arm_upgrade_offline_13.2sp1_allpatterns">
 
-             <span id="res-584984">
-                 <a href="/tests/584984">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+            <span id="res-584984">
+              <a href="/tests/584984">
+                <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+              </a>
+            </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>displaymanager-20140621</li><li>displaymanager-20160502</li><li>displaymanager-20160506</li><li>displaymanager-leap4sap-nousers-20160513</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584984#step/reboot_gnome/14">reboot_gnome</a>
-    </span>
+            <span title='<p>Failed needles:</p><ul><li>displaymanager-20140621</li><li>displaymanager-20160502</li><li>displaymanager-20160506</li><li>displaymanager-leap4sap-nousers-20160513</li></ul>' data-toggle='tooltip' class="failedmodule" >
+            <a href="/tests/584984#step/reboot_gnome/14">reboot_gnome</a>
+          </span>
 
-             <span id="bug-584984">
-        <a href="https://progress.opensuse.org/issues/13212">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13212"></i>
-        </a>
-    </span>
+          <span id="bug-584984">
+            <a href="https://progress.opensuse.org/issues/13212">
+              <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13212"></i>
+            </a>
+          </span>
 
-</td>
+        </td>
 
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1_allpatterns">
+        <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1_allpatterns">
 
-             <span id="res-585020">
-                 <a href="/tests/585020">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-585020">
+            <a href="/tests/585020">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_offline_13.2sp1_smt">upgrade_offline_13.2sp1 ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_offline_13.2sp1_smt">upgrade_offline_13.2sp1 ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1_smt">
+        <td id="res_Gnome-DVD_x86_64_upgrade_offline_13.2sp1_smt">
 
-             <span id="res-584971">
-                 <a href="/tests/584971">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584971">
+            <a href="/tests/584971">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga">upgrade_zdup_offline_sle ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_zdup_offline_13.2_ga">upgrade_zdup_offline_sle ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_upgrade_zdup_offline_13.2_ga">
+        <td id="res_Gnome-DVD_arm_upgrade_zdup_offline_13.2_ga">
 
-             <span id="res-584985">
-                 <a href="/tests/584985">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584985">
+            <a href="/tests/584985">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga">
+        <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga">
 
-             <span id="res-584972">
-                 <a href="/tests/584972">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584972">
+            <a href="/tests/584972">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns">upgrade_zdup_offline_sle ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns">upgrade_zdup_offline_sle ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_upgrade_zdup_offline_13.2_ga_allpatterns">
+        <td id="res_Gnome-DVD_arm_upgrade_zdup_offline_13.2_ga_allpatterns">
 
-             <span id="res-584986">
-                 <a href="/tests/584986">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584986">
+            <a href="/tests/584986">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga_allpatterns">
+        <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga_allpatterns">
 
-             <span id="res-584990">
-                 <a href="/tests/584990">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584990">
+            <a href="/tests/584990">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_zdup_offline_13.2_ga_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga_allpatterns+workaround_deps">
+        <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2_ga_allpatterns+workaround_deps">
 
-             <span id="res-584973">
-                 <a href="/tests/584973">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+          <span id="res-584973">
+            <a href="/tests/584973">
+              <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+            </a>
+          </span>
 
 
-             <span id="bug-584973">
-        <a href="https://progress.opensuse.org/issues/13758">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13758"></i>
-        </a>
-    </span>
+          <span id="bug-584973">
+            <a href="https://progress.opensuse.org/issues/13758">
+              <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13758"></i>
+            </a>
+          </span>
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1">upgrade_zdup_offline_sle ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_zdup_offline_13.2sp1">upgrade_zdup_offline_sle ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1">
+        <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1">
 
-             <span id="res-584974">
-                 <a href="/tests/584974">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584974">
+            <a href="/tests/584974">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns">upgrade_zdup_offline_sle ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns">upgrade_zdup_offline_sle ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1_allpatterns">
+        <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1_allpatterns">
 
-             <span id="res-584426">
-                 <a href="/tests/584426">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+          <span id="res-584426">
+            <a href="/tests/584426">
+              <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+            </a>
+          </span>
 
 
-    <span  class="failedmodule" >
-        <a href="/tests/584426#step/reboot_gnome/10">reboot_gnome</a>
-    </span>
-         +1
+          <span          class="failedmodule" >
+            <a href="/tests/584426#step/reboot_gnome/10">reboot_gnome</a>
+          </span>
+          +1
 
-             <span id="bug-584426">
-        <a href="https://progress.opensuse.org/issues/12758">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12758"></i>
-        </a>
-    </span>
+          <span id="bug-584426">
+            <a href="https://progress.opensuse.org/issues/12758">
+              <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#12758"></i>
+            </a>
+          </span>
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_zdup_offline_13.2sp1_allpatterns+workaround_deps">upgrade_zdup_offline_sle ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1_allpatterns+workaround_deps">
+        <td id="res_Gnome-DVD_x86_64_upgrade_zdup_offline_13.2sp1_allpatterns+workaround_deps">
 
-             <span id="res-585029">
-                 <a href="/tests/585029">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-585029">
+            <a href="/tests/585029">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="upgrade_zdup_online_13.2_ga">upgrade_zdup_online_sle1 ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="upgrade_zdup_online_13.2_ga">upgrade_zdup_online_sle1 ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_upgrade_zdup_online_13.2_ga">
+        <td id="res_Gnome-DVD_x86_64_upgrade_zdup_online_13.2_ga">
 
-             <span id="res-585604">
-                 <a href="/tests/585604">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-585604">
+            <a href="/tests/585604">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">minimal+base</td>
+      </tr>
+      <tr>
+        <td class="name">minimal+base</td>
 
-                            <td id="res_Gnome-DVD_aarch64_minimal+base">
+        <td id="res_Gnome-DVD_aarch64_minimal+base">
 
-             <span id="res-587006">
-                 <a href="/tests/587006">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-587006">
+            <a href="/tests/587006">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                            <td id="res_Gnome-DVD_arm_minimal+base">
+        <td id="res_Gnome-DVD_arm_minimal+base">
 
-             <span id="res-584987">
-                 <a href="/tests/584987">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584987">
+            <a href="/tests/584987">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                            <td id="res_Gnome-DVD_i586_minimal+base">
+        <td id="res_Gnome-DVD_i586_minimal+base">
 
-             <span id="res-584989">
-                 <a href="/tests/584989">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584989">
+            <a href="/tests/584989">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                            <td id="res_Gnome-DVD_x86_64_minimal+base">
+        <td id="res_Gnome-DVD_x86_64_minimal+base">
 
-             <span id="res-585018">
-                 <a href="/tests/585018">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-585018">
+            <a href="/tests/585018">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="minimal+base@i586--l2">minimal+base@i586--vsw ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="minimal+base@i586--l2">minimal+base@i586--vsw ...</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_minimal+base@i586--l2">
+        <td id="res_Gnome-DVD_i586_minimal+base@i586--l2">
 
-             <span id="res-582675">
-                 <a href="/tests/582675">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+          <span id="res-582675">
+            <a href="/tests/582675">
+              <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+            </a>
+          </span>
 
 
-             <span id="bug-582675">
-        <a href="https://progress.opensuse.org/issues/13758">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13758"></i>
-        </a>
-    </span>
+          <span id="bug-582675">
+            <a href="https://progress.opensuse.org/issues/13758">
+              <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13758"></i>
+            </a>
+          </span>
 
-</td>
+        </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">minimal_x</td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td class="name">minimal_x</td>
 
-                            <td id="res_Gnome-DVD_aarch64_minimal_x">
+        <td id="res_Gnome-DVD_aarch64_minimal_x">
 
-             <span id="res-587003">
-                 <a href="/tests/587003">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-587003">
+            <a href="/tests/587003">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                            <td id="res_Gnome-DVD_arm_minimal_x">
+        <td id="res_Gnome-DVD_arm_minimal_x">
 
-             <span id="res-584993">
-                 <a href="/tests/584993">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584993">
+            <a href="/tests/584993">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_minimal_x">
+        <td id="res_Gnome-DVD_x86_64_minimal_x">
 
-             <span id="res-585016">
-                 <a href="/tests/585016">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-585016">
+            <a href="/tests/585016">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">minimal_x+uefi</td>
+      </tr>
+      <tr>
+        <td class="name">minimal_x+uefi</td>
 
-                            <td id="res_Gnome-DVD_aarch64_minimal_x+uefi">
+        <td id="res_Gnome-DVD_aarch64_minimal_x+uefi">
 
-             <span id="res-584991">
-                 <a href="/tests/584991">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584991">
+            <a href="/tests/584991">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">minimal_x+uefi@uefi</td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td class="name">minimal_x+uefi@uefi</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_minimal_x+uefi@uefi">
+        <td id="res_Gnome-DVD_x86_64_minimal_x+uefi@uefi">
 
-             <span id="res-585014">
-                 <a href="/tests/585014">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-585014">
+            <a href="/tests/585014">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">multipath</td>
+      </tr>
+      <tr>
+        <td class="name">multipath</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_multipath">
+        <td id="res_Gnome-DVD_x86_64_multipath">
 
-             <span id="res-584899">
-                 <a href="/tests/584899">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584899">
+            <a href="/tests/584899">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">multipath@arm-no-tmpfs</td>
+      </tr>
+      <tr>
+        <td class="name">multipath@arm-no-tmpfs</td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_multipath@arm-no-tmpfs">
+        <td id="res_Gnome-DVD_arm_multipath@arm-no-tmpfs">
 
-             <span id="res-582656">
-                 <a href="/tests/582656">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-582656">
+            <a href="/tests/582656">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                                <td>-</td>
+        <td>-</td>
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">rescue_system_13.1sp4</td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td class="name">rescue_system_13.1sp4</td>
 
-                            <td id="res_Gnome-DVD_aarch64_rescue_system_13.1sp4">
+        <td id="res_Gnome-DVD_aarch64_rescue_system_13.1sp4">
 
-             <span id="res-584777">
-                 <a href="/tests/584777">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584777">
+            <a href="/tests/584777">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                            <td id="res_Gnome-DVD_arm_rescue_system_13.1sp4">
+        <td id="res_Gnome-DVD_arm_rescue_system_13.1sp4">
 
-             <span id="res-582634">
-                 <a href="/tests/582634">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-582634">
+            <a href="/tests/582634">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_rescue_system_13.1sp4">
+        <td id="res_Gnome-DVD_x86_64_rescue_system_13.1sp4">
 
-             <span id="res-584451">
-                 <a href="/tests/584451">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+          <span id="res-584451">
+            <a href="/tests/584451">
+              <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+            </a>
+          </span>
 
 
 
-</td>
+        </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline ...</span></td>
+      </tr>
+      <tr>
+        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline</span></td>
 
-                                <td>-</td>
+        <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2">
+        <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2">
 
-             <span id="res-585615">
-                 <a href="/tests/585615">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+          <span id="res-585615">
+            <a href="/tests/585615">
+              <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+            </a>
+          </span>
 
 
-    <span title='<p>Failed needles:</p><ul><li>autoyast-system-login-console-20150529</li><li>autoyast-system-login-console-minimal-20160113</li><li>linux-login-20150120</li><li>linux-login-20150922</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/585615#step/snapper_rollback/7">snapper_rollback</a>
-    </span>
+          <span title='<p>Failed needles:</p><ul><li>autoyast-system-login-console-20150529</li><li>autoyast-system-login-console-minimal-20160113</li><li>linux-login-20150120</li><li>linux-login-20150922</li></ul>' data-toggle='tooltip' class="failedmodule" >
+          <a href="/tests/585615#step/snapper_rollback/7">snapper_rollback</a>
+        </span>
 
-             <span id="bug-585615">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=980337">
+        <span id="bug-585615">
+          <a href="https://bugzilla.suse.com/show_bug.cgi?id=980337">
             <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#980337"></i>
-        </a>
-    </span>
+          </a>
+        </span>
 
-</td>
-
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_rollback_upgrade_offline_13.2">
-
-             <span id="res-584968">
-                 <a href="/tests/584968">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+      </td>
 
 
-    <span title='<p>Failed needles:</p><ul><li>autoyast-system-login-console-20150529</li><li>autoyast-system-login-console-minimal-20160113</li><li>linux-login-20150120</li><li>linux-login-20150922</li></ul>' data-toggle='tooltip' class="failedmodule" >
+      <td>-</td>
+
+      <td id="res_Gnome-DVD_x86_64_rollback_upgrade_offline_13.2">
+
+        <span id="res-584968">
+          <a href="/tests/584968">
+            <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+          </a>
+        </span>
+
+
+        <span title='<p>Failed needles:</p><ul><li>autoyast-system-login-console-20150529</li><li>autoyast-system-login-console-minimal-20160113</li><li>linux-login-20150120</li><li>linux-login-20150922</li></ul>' data-toggle='tooltip' class="failedmodule" >
         <a href="/tests/584968#step/snapper_rollback/3">snapper_rollback</a>
-    </span>
+      </span>
 
-             <span id="bug-584968">
+      <span id="bug-584968">
         <a href="https://bugzilla.suse.com/show_bug.cgi?id=980337">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#980337"></i>
+          <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#980337"></i>
         </a>
-    </span>
+      </span>
 
-</td>
+    </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline ...</span></td>
+  </tr>
+  <tr>
+    <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline</span></td>
 
-                                <td>-</td>
+    <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2sp1">
+    <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2sp1">
 
-             <span id="res-585619">
-                 <a href="/tests/585619">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
-
-
-    <span title='<p>Failed needles:</p><ul><li>autoyast-system-login-console-20150529</li><li>autoyast-system-login-console-minimal-20160113</li><li>linux-login-20150120</li><li>linux-login-20150922</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/585619#step/snapper_rollback/6">snapper_rollback</a>
-    </span>
-
-             <span id="bug-585619">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=980337">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#980337"></i>
+      <span id="res-585619">
+        <a href="/tests/585619">
+          <i class="status fa fa-circle result_failed" title="Done: failed"></i>
         </a>
+      </span>
+
+
+      <span title='<p>Failed needles:</p><ul><li>autoyast-system-login-console-20150529</li><li>autoyast-system-login-console-minimal-20160113</li><li>linux-login-20150120</li><li>linux-login-20150922</li></ul>' data-toggle='tooltip' class="failedmodule" >
+      <a href="/tests/585619#step/snapper_rollback/6">snapper_rollback</a>
     </span>
 
-</td>
+    <span id="bug-585619">
+      <a href="https://bugzilla.suse.com/show_bug.cgi?id=980337">
+        <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#980337"></i>
+      </a>
+    </span>
+
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_rollback_upgrade_offline_13.2sp1">
+  <td id="res_Gnome-DVD_x86_64_rollback_upgrade_offline_13.2sp1">
 
-             <span id="res-584976">
-                 <a href="/tests/584976">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+    <span id="res-584976">
+      <a href="/tests/584976">
+        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+      </a>
+    </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>gnome_terminal-20160511</li><li>gnome_terminal-20160520</li><li>gnome_terminal-20160525</li><li>gnome_terminal-20160713</li><li>gnome_terminal-20160714</li><li>gnome_terminal-gnome-terminal-20160523</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584976#step/gnome_terminal/4">gnome_terminal</a>
+    <a href="/tests/584976#step/gnome_terminal/4">gnome_terminal</a>
+  </span>
+  +7
+
+  <span id="bug-584976">
+    <a href="https://progress.opensuse.org/issues/13156">
+      <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13156"></i>
+    </a>
+  </span>
+
+</td>
+
+</tr>
+<tr>
+  <td class="name">gcc5</td>
+
+  <td id="res_Gnome-DVD_aarch64_gcc5">
+
+    <span id="res-585030">
+      <a href="/tests/585030">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
     </span>
-         +7
 
-             <span id="bug-584976">
-        <a href="https://progress.opensuse.org/issues/13156">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13156"></i>
-        </a>
+
+
+  </td>
+
+
+  <td id="res_Gnome-DVD_arm_gcc5">
+
+    <span id="res-585616">
+      <a href="/tests/585616">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
     </span>
 
-</td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gcc5</td>
 
-                            <td id="res_Gnome-DVD_aarch64_gcc5">
+  </td>
 
-             <span id="res-585030">
-                 <a href="/tests/585030">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
 
+  <td>-</td>
 
+  <td id="res_Gnome-DVD_x86_64_gcc5">
 
-</td>
+    <span id="res-585012">
+      <a href="/tests/585012">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
-                            <td id="res_Gnome-DVD_arm_gcc5">
 
-             <span id="res-585616">
-                 <a href="/tests/585616">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  </td>
 
+</tr>
+<tr>
+  <td class="name">gcc5+allpatterns</td>
 
+  <td id="res_Gnome-DVD_aarch64_gcc5+allpatterns">
 
-</td>
+    <span id="res-584995">
+      <a href="/tests/584995">
+        <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+      </a>
+    </span>
 
 
-                                <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_gcc5">
+  </td>
 
-             <span id="res-585012">
-                 <a href="/tests/585012">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
 
+  <td id="res_Gnome-DVD_arm_gcc5+allpatterns">
 
+    <span id="res-585767">
+      <a href="/tests/585767">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
-</td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gcc5+allpatterns</td>
 
-                            <td id="res_Gnome-DVD_aarch64_gcc5+allpatterns">
+  </td>
 
-             <span id="res-584995">
-                 <a href="/tests/584995">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
 
+  <td>-</td>
 
+  <td id="res_Gnome-DVD_x86_64_gcc5+allpatterns">
 
-</td>
+    <span id="res-585013">
+      <a href="/tests/585013">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
-                            <td id="res_Gnome-DVD_arm_gcc5+allpatterns">
 
-             <span id="res-585767">
-                 <a href="/tests/585767">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  </td>
 
+</tr>
+<tr>
+  <td class="name">gcc5-ftp</td>
 
+  <td id="res_Gnome-DVD_aarch64_gcc5-ftp">
 
-</td>
+    <span id="res-585638">
+      <a href="/tests/585638">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
-                                <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_gcc5+allpatterns">
+  </td>
 
-             <span id="res-585013">
-                 <a href="/tests/585013">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
 
+  <td id="res_Gnome-DVD_arm_gcc5-ftp">
 
+    <span id="res-585617">
+      <a href="/tests/585617">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
-</td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gcc5-ftp</td>
 
-                            <td id="res_Gnome-DVD_aarch64_gcc5-ftp">
+  </td>
 
-             <span id="res-585638">
-                 <a href="/tests/585638">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
 
+  <td>-</td>
 
+  <td id="res_Gnome-DVD_x86_64_gcc5-ftp">
 
-</td>
+    <span id="res-585011">
+      <a href="/tests/585011">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
-                            <td id="res_Gnome-DVD_arm_gcc5-ftp">
 
-             <span id="res-585617">
-                 <a href="/tests/585617">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  </td>
 
+</tr>
+<tr>
+  <td class="name">gcc5-ftp@i586--l3</td>
 
+  <td>-</td>
 
-</td>
+  <td>-</td>
 
+  <td id="res_Gnome-DVD_i586_gcc5-ftp@i586--l3">
 
-                                <td>-</td>
+    <span id="res-582670">
+      <a href="/tests/582670">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
-                            <td id="res_Gnome-DVD_x86_64_gcc5-ftp">
 
-             <span id="res-585011">
-                 <a href="/tests/585011">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
 
+  </td>
 
 
-</td>
+  <td>-</td>
+</tr>
+<tr>
+  <td class="name">gcc5-http</td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gcc5-ftp@i586--l3</td>
+  <td id="res_Gnome-DVD_aarch64_gcc5-http">
 
-                                <td>-</td>
+    <span id="res-587007">
+      <a href="/tests/587007">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
-                                <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_gcc5-ftp@i586--l3">
 
-             <span id="res-582670">
-                 <a href="/tests/582670">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  </td>
 
 
+  <td id="res_Gnome-DVD_arm_gcc5-http">
 
-</td>
+    <span id="res-585635">
+      <a href="/tests/585635">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">gcc5-http</td>
 
-                            <td id="res_Gnome-DVD_aarch64_gcc5-http">
+  </td>
 
-             <span id="res-587007">
-                 <a href="/tests/587007">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
 
+  <td>-</td>
 
+  <td id="res_Gnome-DVD_x86_64_gcc5-http">
 
-</td>
+    <span id="res-585010">
+      <a href="/tests/585010">
+        <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
+      </a>
+    </span>
 
 
-                            <td id="res_Gnome-DVD_arm_gcc5-http">
 
-             <span id="res-585635">
-                 <a href="/tests/585635">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  </td>
 
+</tr>
+<tr>
+  <td class="name">leap+extratests</td>
 
+  <td id="res_Gnome-DVD_aarch64_leap+extratests">
 
-</td>
-
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_gcc5-http">
-
-             <span id="res-585010">
-                 <a href="/tests/585010">
-                     <i class="status fa fa-circle result_softfailed" title="Done: softfailed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">leap+extratests</td>
-
-                            <td id="res_Gnome-DVD_aarch64_leap+extratests">
-
-             <span id="res-587020">
-                 <a href="/tests/587020">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+    <span id="res-587020">
+      <a href="/tests/587020">
+        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+      </a>
+    </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/587020#step/boot_to_desktop/3">boot_to_desktop</a>
+      <a href="/tests/587020#step/boot_to_desktop/3">boot_to_desktop</a>
     </span>
 
-             <span id="bug-587020">
-        <a href="https://progress.opensuse.org/issues/11948">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#11948"></i>
-        </a>
+    <span id="bug-587020">
+      <a href="https://progress.opensuse.org/issues/11948">
+        <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#11948"></i>
+      </a>
     </span>
 
-</td>
+  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_leap+extratests">
+  <td id="res_Gnome-DVD_arm_leap+extratests">
 
-             <span id="res-582664">
-                 <a href="/tests/582664">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+    <span id="res-582664">
+      <a href="/tests/582664">
+        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+      </a>
+    </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/582664#step/snapper_cleanup/98">snapper_cleanup</a>
+      <a href="/tests/582664#step/snapper_cleanup/98">snapper_cleanup</a>
     </span>
-         +4
+    +4
 
-             <span id="bug-582664">
-        <a href="https://progress.opensuse.org/issues/13598">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13598"></i>
-        </a>
+    <span id="bug-582664">
+      <a href="https://progress.opensuse.org/issues/13598">
+        <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13598"></i>
+      </a>
     </span>
 
-</td>
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_leap+extratests">
+  <td id="res_Gnome-DVD_x86_64_leap+extratests">
 
-             <span id="res-587004">
-                 <a href="/tests/587004">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+    <span id="res-587004">
+      <a href="/tests/587004">
+        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+      </a>
+    </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/587004#step/btrfs_qgroups/62">btrfs_qgroups</a>
+      <a href="/tests/587004#step/btrfs_qgroups/62">btrfs_qgroups</a>
     </span>
-         +6
+    +6
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">leap12_gnome_create_hdd</td>
+</tr>
+<tr>
+  <td class="name">leap12_gnome_create_hdd</td>
 
-                            <td id="res_Gnome-DVD_aarch64_leap12_gnome_create_hdd">
+  <td id="res_Gnome-DVD_aarch64_leap12_gnome_create_hdd">
 
-             <span id="res-584848">
-                 <a href="/tests/584848">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584848">
+      <a href="/tests/584848">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_leap12_gnome_create_hdd">
+  <td id="res_Gnome-DVD_arm_leap12_gnome_create_hdd">
 
-             <span id="res-582576">
-                 <a href="/tests/582576">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-582576">
+      <a href="/tests/582576">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_leap12_gnome_create_hdd">
+  <td id="res_Gnome-DVD_x86_64_leap12_gnome_create_hdd">
 
-             <span id="res-584341">
-                 <a href="/tests/584341">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584341">
+      <a href="/tests/584341">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_minimal_base+gcc5_create_hdd">leap12_minimal_base+gcc5_cr ...</span></td>
+</tr>
+<tr>
+  <td class="name"><span title="leap12_minimal_base+gcc5_create_hdd">leap12_minimal_base+gcc5_cr ...</span></td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_leap12_minimal_base+gcc5_create_hdd">
+  <td id="res_Gnome-DVD_arm_leap12_minimal_base+gcc5_create_hdd">
 
-             <span id="res-584680">
-                 <a href="/tests/584680">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584680">
+      <a href="/tests/584680">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_leap12_minimal_base+gcc5_create_hdd">
+  <td id="res_Gnome-DVD_x86_64_leap12_minimal_base+gcc5_create_hdd">
 
-             <span id="res-584342">
-                 <a href="/tests/584342">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584342">
+      <a href="/tests/584342">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_qa_acceptance_fs_stress">leap12_qa_acceptance_fs_st ...</span></td>
+</tr>
+<tr>
+  <td class="name"><span title="leap12_qa_acceptance_fs_stress">leap12_qa_acceptance_fs_st ...</span></td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_fs_stress">
+  <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_fs_stress">
 
-             <span id="res-584633">
-                 <a href="/tests/584633">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584633">
+      <a href="/tests/584633">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_fs_stress">
+  <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_fs_stress">
 
-             <span id="res-584507">
-                 <a href="/tests/584507">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584507">
+      <a href="/tests/584507">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_qa_acceptance_process_stress">leap12_qa_acceptance_proce ...</span></td>
+</tr>
+<tr>
+  <td class="name"><span title="leap12_qa_acceptance_process_stress">leap12_qa_acceptance_proce ...</span></td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_process_stress">
+  <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_process_stress">
 
-             <span id="res-584632">
-                 <a href="/tests/584632">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584632">
+      <a href="/tests/584632">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_process_stress">
+  <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_process_stress">
 
-             <span id="res-584508">
-                 <a href="/tests/584508">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584508">
+      <a href="/tests/584508">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="leap12_qa_acceptance_sched_stress">leap12_qa_acceptance_sched ...</span></td>
+</tr>
+<tr>
+  <td class="name"><span title="leap12_qa_acceptance_sched_stress">leap12_qa_acceptance_sched ...</span></td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_sched_stress">
+  <td id="res_Gnome-DVD_arm_leap12_qa_acceptance_sched_stress">
 
-             <span id="res-584631">
-                 <a href="/tests/584631">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584631">
+      <a href="/tests/584631">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_sched_stress">
+  <td id="res_Gnome-DVD_x86_64_leap12_qa_acceptance_sched_stress">
 
-             <span id="res-584696">
-                 <a href="/tests/584696">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584696">
+      <a href="/tests/584696">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">smt</td>
+</tr>
+<tr>
+  <td class="name">smt</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_smt">
+  <td id="res_Gnome-DVD_x86_64_smt">
 
-             <span id="res-585009">
-                 <a href="/tests/585009">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-585009">
+      <a href="/tests/585009">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">ssh-X@i586--l3</td>
+</tr>
+<tr>
+  <td class="name">ssh-X@i586--l3</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_ssh-X@i586--l3">
+  <td id="res_Gnome-DVD_i586_ssh-X@i586--l3">
 
-             <span id="res-582673">
-                 <a href="/tests/582673">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-582673">
+      <a href="/tests/582673">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">textmode</td>
+  <td>-</td>
+</tr>
+<tr>
+  <td class="name">textmode</td>
 
-                            <td id="res_Gnome-DVD_aarch64_textmode">
+  <td id="res_Gnome-DVD_aarch64_textmode">
 
-             <span id="res-584996">
-                 <a href="/tests/584996">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584996">
+      <a href="/tests/584996">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                            <td id="res_Gnome-DVD_arm_textmode">
+  <td id="res_Gnome-DVD_arm_textmode">
 
-             <span id="res-584998">
-                 <a href="/tests/584998">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584998">
+      <a href="/tests/584998">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                            <td id="res_Gnome-DVD_i586_textmode">
+  <td id="res_Gnome-DVD_i586_textmode">
 
-             <span id="res-585002">
-                 <a href="/tests/585002">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-585002">
+      <a href="/tests/585002">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                            <td id="res_Gnome-DVD_x86_64_textmode">
+  <td id="res_Gnome-DVD_x86_64_textmode">
 
-             <span id="res-585008">
-                 <a href="/tests/585008">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-585008">
+      <a href="/tests/585008">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">textmode+kvm_server_role</td>
+</tr>
+<tr>
+  <td class="name">textmode+kvm_server_role</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_textmode+kvm_server_role">
+  <td id="res_Gnome-DVD_x86_64_textmode+kvm_server_role">
 
-             <span id="res-585007">
-                 <a href="/tests/585007">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-585007">
+      <a href="/tests/585007">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">textmode@i586--l3</td>
+</tr>
+<tr>
+  <td class="name">textmode@i586--l3</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_textmode@i586--l3">
+  <td id="res_Gnome-DVD_i586_textmode@i586--l3">
 
-             <span id="res-584629">
-                 <a href="/tests/584629">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584629">
+      <a href="/tests/584629">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">toolchain_zypper</td>
+  <td>-</td>
+</tr>
+<tr>
+  <td class="name">toolchain_zypper</td>
 
-                            <td id="res_Gnome-DVD_aarch64_toolchain_zypper">
+  <td id="res_Gnome-DVD_aarch64_toolchain_zypper">
 
-             <span id="res-584781">
-                 <a href="/tests/584781">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584781">
+      <a href="/tests/584781">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_i586_toolchain_zypper">
+  <td id="res_Gnome-DVD_i586_toolchain_zypper">
 
-             <span id="res-582671">
-                 <a href="/tests/582671">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+    <span id="res-582671">
+      <a href="/tests/582671">
+        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+      </a>
+    </span>
 
 
     <span  class="failedmodule" >
-        <a href="/tests/582671#step/gcc5_C_compilation/135">gcc5_C_compilation</a>
+      <a href="/tests/582671#step/gcc5_C_compilation/135">gcc5_C_compilation</a>
     </span>
 
-             <span id="bug-582671">
-        <a href="https://progress.opensuse.org/issues/13294">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13294"></i>
-        </a>
+    <span id="bug-582671">
+      <a href="https://progress.opensuse.org/issues/13294">
+        <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13294"></i>
+      </a>
     </span>
 
-</td>
+  </td>
 
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">toolchain_zypper@64bit-smp</td>
+  <td>-</td>
+</tr>
+<tr>
+  <td class="name">toolchain_zypper@64bit-smp</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_toolchain_zypper@64bit-smp">
+  <td id="res_Gnome-DVD_x86_64_toolchain_zypper@64bit-smp">
 
-             <span id="res-584327">
-                 <a href="/tests/584327">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">toolchain_zypper@arm-smp</td>
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_arm_toolchain_zypper@arm-smp">
-
-             <span id="res-582575">
-                 <a href="/tests/582575">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584327">
+      <a href="/tests/584327">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
+</tr>
+<tr>
+  <td class="name">toolchain_zypper@arm-smp</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">we</td>
+  <td id="res_Gnome-DVD_arm_toolchain_zypper@arm-smp">
 
-                                <td>-</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_we">
-
-             <span id="res-585005">
-                 <a href="/tests/585005">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-582575">
+      <a href="/tests/582575">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">we+allpatterns</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_we+allpatterns">
-
-             <span id="res-585004">
-                 <a href="/tests/585004">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  </td>
 
 
+  <td>-</td>
 
-</td>
+  <td>-</td>
+</tr>
+<tr>
+  <td class="name">we</td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">we-ftp</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td id="res_Gnome-DVD_x86_64_we">
 
-                            <td id="res_Gnome-DVD_x86_64_we-ftp">
+    <span id="res-585005">
+      <a href="/tests/585005">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
-             <span id="res-584313">
-                 <a href="/tests/584313">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+
+
+  </td>
+
+</tr>
+<tr>
+  <td class="name">we+allpatterns</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td id="res_Gnome-DVD_x86_64_we+allpatterns">
+
+    <span id="res-585004">
+      <a href="/tests/585004">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+</tr>
+<tr>
+  <td class="name">we-ftp</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td id="res_Gnome-DVD_x86_64_we-ftp">
+
+    <span id="res-584313">
+      <a href="/tests/584313">
+        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+      </a>
+    </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>desktop-runner-20140523</li><li>desktop-runner-20160502</li><li>desktop-runner-20160504</li><li>desktop-runner-20160713</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584313#step/updates_packagekit_gpk/17">updates_packagekit_gpk</a>
-    </span>
-         +1
+    <a href="/tests/584313#step/updates_packagekit_gpk/17">updates_packagekit_gpk</a>
+  </span>
+  +1
 
-             <span id="bug-584313">
-        <a href="https://progress.opensuse.org/issues/13610">
-            <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13610"></i>
-        </a>
-    </span>
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">we-http</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_we-http">
-
-             <span id="res-585003">
-                 <a href="/tests/585003">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
+  <span id="bug-584313">
+    <a href="https://progress.opensuse.org/issues/13610">
+      <i class="test-label label_bug fa fa-bolt" title="Bug(s) referenced: poo#13610"></i>
+    </a>
+  </span>
 
 </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">xen</td>
+</tr>
+<tr>
+  <td class="name">we-http</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                                <td>-</td>
+  <td>-</td>
 
-                            <td id="res_Gnome-DVD_x86_64_xen">
+  <td id="res_Gnome-DVD_x86_64_we-http">
 
-             <span id="res-584457">
-                 <a href="/tests/584457">
-                     <i class="status fa fa-circle result_failed" title="Done: failed"></i>
-                 </a>
-             </span>
+    <span id="res-585003">
+      <a href="/tests/585003">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+</tr>
+<tr>
+  <td class="name">xen</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td id="res_Gnome-DVD_x86_64_xen">
+
+    <span id="res-584457">
+      <a href="/tests/584457">
+        <i class="status fa fa-circle result_failed" title="Done: failed"></i>
+      </a>
+    </span>
 
 
     <span title='<p>Failed needles:</p><ul><li>yast2_snapper-new_snapshot-20160708</li><li>yast2_snapper-new_snapshot-SP2-20160713</li><li>yast2_snapper-new_snapshot_selected-20160312</li><li>yast2_snapper-new_snapshot_selected-20160505</li><li>yast2_snapper-new_snapshot_selected-GA-20160315</li><li>yast2_snapper-new_snapshot_selected-SP2-20160713</li><li>yast2_snapper-snapshots-20160310</li><li>yast2_snapper-snapshots-20160503</li><li>yast2_snapper-snapshots-20160504</li><li>yast2_snapper-snapshots-SP2-20160713</li></ul>' data-toggle='tooltip' class="failedmodule" >
-        <a href="/tests/584457#step/yast2_snapper/44">yast2_snapper</a>
-    </span>
-         +1
+    <a href="/tests/584457#step/yast2_snapper/44">yast2_snapper</a>
+  </span>
+  +1
 
-             <span id="bug-584457">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=963567">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#963567"></i>
-        </a>
-    </span>
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">xfs</td>
-
-                            <td id="res_Gnome-DVD_aarch64_xfs">
-
-             <span id="res-584782">
-                 <a href="/tests/584782">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
+  <span id="bug-584457">
+    <a href="https://bugzilla.suse.com/show_bug.cgi?id=963567">
+      <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#963567"></i>
+    </a>
+  </span>
 
 </td>
 
-
-                            <td id="res_Gnome-DVD_arm_xfs">
-
-             <span id="res-582641">
-                 <a href="/tests/582641">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                            <td id="res_Gnome-DVD_i586_xfs">
-
-             <span id="res-582688">
-                 <a href="/tests/582688">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                            <td id="res_Gnome-DVD_x86_64_xfs">
-
-             <span id="res-584458">
-                 <a href="/tests/584458">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">xfs@i586--l2</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_i586_xfs@i586--l2">
-
-             <span id="res-582676">
-                 <a href="/tests/582676">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                                <td>-</td>
-                    </tr>
-                    <tr>
-                        <td class="name">yast_hostname</td>
-
-                            <td id="res_Gnome-DVD_aarch64_yast_hostname">
-
-             <span id="res-584806">
-                 <a href="/tests/584806">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                            <td id="res_Gnome-DVD_arm_yast_hostname">
-
-             <span id="res-582567">
-                 <a href="/tests/582567">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_yast_hostname">
-
-             <span id="res-584461">
-                 <a href="/tests/584461">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">yast_hostname+dhcp_hostname</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_yast_hostname+dhcp_hostname">
-
-             <span id="res-584487">
-                 <a href="/tests/584487">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name"><span title="yast_hostname+linuxrc_hostname">yast_hostname+linuxrc_host ...</span></td>
-
-                            <td id="res_Gnome-DVD_aarch64_yast_hostname+linuxrc_hostname">
-
-             <span id="res-584807">
-                 <a href="/tests/584807">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                            <td id="res_Gnome-DVD_arm_yast_hostname+linuxrc_hostname">
-
-             <span id="res-582648">
-                 <a href="/tests/582648">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_x86_64_yast_hostname+linuxrc_hostname">
-
-             <span id="res-584488">
-                 <a href="/tests/584488">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">yast_no_self_update</td>
-
-                            <td id="res_Gnome-DVD_aarch64_yast_no_self_update">
-
-             <span id="res-584801">
-                 <a href="/tests/584801">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                            <td id="res_Gnome-DVD_arm_yast_no_self_update">
-
-             <span id="res-582566">
-                 <a href="/tests/582566">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                            <td id="res_Gnome-DVD_i586_yast_no_self_update">
-
-             <span id="res-582694">
-                 <a href="/tests/582694">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-
-                            <td id="res_Gnome-DVD_x86_64_yast_no_self_update">
-
-             <span id="res-584460">
-                 <a href="/tests/584460">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
-
-
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">zfcp@i586-zfcp</td>
-
-                                <td>-</td>
-
-                                <td>-</td>
-
-                            <td id="res_Gnome-DVD_i586_zfcp@i586-zfcp">
-
-             <span id="res-584922">
-                 <a href="/tests/584922">
-                     <i class="status fa fa-circle result_incomplete" title="Done: incomplete"></i>
-                 </a>
-             </span>
-
-
-             <span id="bug-584922">
-        <a href="https://bugzilla.suse.com/show_bug.cgi?id=986374">
-            <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#986374"></i>
-        </a>
+</tr>
+<tr>
+  <td class="name">xfs</td>
+
+  <td id="res_Gnome-DVD_aarch64_xfs">
+
+    <span id="res-584782">
+      <a href="/tests/584782">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
     </span>
 
-</td>
 
 
-                                <td>-</td>
-                    </tr>
-            </tbody>
-        </table>
-        <h3>Flavor: Gnome-MINI-ISO</h3>
-        <table id="results_Gnome-MINI-ISO" class="overview table table-striped table-hover">
-            <thead>
-                <tr id="flavors">
-                    <th>Test</th>
-                        <th id="flavor_Gnome-MINI-ISO_arch_x86_64">x86_64</th>
-                </tr>
-            </thead>
-            <tbody>
-                    <tr>
-                        <td class="name">gnome_http</td>
+  </td>
 
-                            <td id="res_Gnome-MINI-ISO_x86_64_gnome_http">
 
-             <span id="res-584619">
-                 <a href="/tests/584619">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  <td id="res_Gnome-DVD_arm_xfs">
+
+    <span id="res-582641">
+      <a href="/tests/582641">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">gnome_http_autoyast</td>
 
-                            <td id="res_Gnome-MINI-ISO_x86_64_gnome_http_autoyast">
+  <td id="res_Gnome-DVD_i586_xfs">
 
-             <span id="res-584620">
-                 <a href="/tests/584620">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-582688">
+      <a href="/tests/582688">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">remote_ssh_controller</td>
 
-                            <td id="res_Gnome-MINI-ISO_x86_64_remote_ssh_controller">
+  <td id="res_Gnome-DVD_x86_64_xfs">
 
-             <span id="res-584618">
-                 <a href="/tests/584618">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-584458">
+      <a href="/tests/584458">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
+  </td>
 
-                    </tr>
-                    <tr>
-                        <td class="name">remote_ssh_target_ftp</td>
+</tr>
+<tr>
+  <td class="name">xfs@i586--l2</td>
 
-                            <td id="res_Gnome-MINI-ISO_x86_64_remote_ssh_target_ftp">
+  <td>-</td>
 
-             <span id="res-584617">
-                 <a href="/tests/584617">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  <td>-</td>
 
+  <td id="res_Gnome-DVD_i586_xfs@i586--l2">
 
-
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">remote_vnc_controller</td>
-
-                            <td id="res_Gnome-MINI-ISO_x86_64_remote_vnc_controller">
-
-             <span id="res-584616">
-                 <a href="/tests/584616">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+    <span id="res-582676">
+      <a href="/tests/582676">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
 
 
 
-</td>
-
-                    </tr>
-                    <tr>
-                        <td class="name">remote_vnc_target_nfs</td>
-
-                            <td id="res_Gnome-MINI-ISO_x86_64_remote_vnc_target_nfs">
-
-             <span id="res-584615">
-                 <a href="/tests/584615">
-                     <i class="status fa fa-circle result_passed" title="Done: passed"></i>
-                 </a>
-             </span>
+  </td>
 
 
+  <td>-</td>
+</tr>
+<tr>
+  <td class="name">yast_hostname</td>
 
-</td>
+  <td id="res_Gnome-DVD_aarch64_yast_hostname">
 
-                    </tr>
-            </tbody>
-        </table>
+    <span id="res-584806">
+      <a href="/tests/584806">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+
+  <td id="res_Gnome-DVD_arm_yast_hostname">
+
+    <span id="res-582567">
+      <a href="/tests/582567">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+
+  <td>-</td>
+
+  <td id="res_Gnome-DVD_x86_64_yast_hostname">
+
+    <span id="res-584461">
+      <a href="/tests/584461">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+</tr>
+<tr>
+  <td class="name">yast_hostname+dhcp_hostname</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td id="res_Gnome-DVD_x86_64_yast_hostname+dhcp_hostname">
+
+    <span id="res-584487">
+      <a href="/tests/584487">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+</tr>
+<tr>
+  <td class="name"><span title="yast_hostname+linuxrc_hostname">yast_hostname+linuxrc_host ...</span></td>
+
+  <td id="res_Gnome-DVD_aarch64_yast_hostname+linuxrc_hostname">
+
+    <span id="res-584807">
+      <a href="/tests/584807">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+
+  <td id="res_Gnome-DVD_arm_yast_hostname+linuxrc_hostname">
+
+    <span id="res-582648">
+      <a href="/tests/582648">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+
+  <td>-</td>
+
+  <td id="res_Gnome-DVD_x86_64_yast_hostname+linuxrc_hostname">
+
+    <span id="res-584488">
+      <a href="/tests/584488">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+</tr>
+<tr>
+  <td class="name">yast_no_self_update</td>
+
+  <td id="res_Gnome-DVD_aarch64_yast_no_self_update">
+
+    <span id="res-584801">
+      <a href="/tests/584801">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+
+  <td id="res_Gnome-DVD_arm_yast_no_self_update">
+
+    <span id="res-582566">
+      <a href="/tests/582566">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+
+  <td id="res_Gnome-DVD_i586_yast_no_self_update">
+
+    <span id="res-582694">
+      <a href="/tests/582694">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+
+  <td id="res_Gnome-DVD_x86_64_yast_no_self_update">
+
+    <span id="res-584460">
+      <a href="/tests/584460">
+        <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+      </a>
+    </span>
+
+
+
+  </td>
+
+</tr>
+<tr>
+  <td class="name">zfcp@i586-zfcp</td>
+
+  <td>-</td>
+
+  <td>-</td>
+
+  <td id="res_Gnome-DVD_i586_zfcp@i586-zfcp">
+
+    <span id="res-584922">
+      <a href="/tests/584922">
+        <i class="status fa fa-circle result_incomplete" title="Done: incomplete"></i>
+      </a>
+    </span>
+
+
+    <span id="bug-584922">
+      <a href="https://bugzilla.suse.com/show_bug.cgi?id=986374">
+        <i class="test-label label_bug fa fa-bug" title="Bug(s) referenced: bsc#986374"></i>
+      </a>
+    </span>
+
+  </td>
+
+
+  <td>-</td>
+</tr>
+</tbody>
+</table>
+<h3>Flavor: Gnome-MINI-ISO</h3>
+<table id="results_Gnome-MINI-ISO" class="overview table table-striped table-hover">
+  <thead>
+    <tr id="flavors">
+      <th>Test</th>
+      <th id="flavor_Gnome-MINI-ISO_arch_x86_64">x86_64</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="name">gnome_http</td>
+
+      <td id="res_Gnome-MINI-ISO_x86_64_gnome_http">
+
+        <span id="res-584619">
+          <a href="/tests/584619">
+            <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+          </a>
+        </span>
+
+
+
+      </td>
+
+    </tr>
+    <tr>
+      <td class="name">gnome_http_autoyast</td>
+
+      <td id="res_Gnome-MINI-ISO_x86_64_gnome_http_autoyast">
+
+        <span id="res-584620">
+          <a href="/tests/584620">
+            <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+          </a>
+        </span>
+
+
+
+      </td>
+
+    </tr>
+    <tr>
+      <td class="name">remote_ssh_controller</td>
+
+      <td id="res_Gnome-MINI-ISO_x86_64_remote_ssh_controller">
+
+        <span id="res-584618">
+          <a href="/tests/584618">
+            <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+          </a>
+        </span>
+
+
+
+      </td>
+
+    </tr>
+    <tr>
+      <td class="name">remote_ssh_target_ftp</td>
+
+      <td id="res_Gnome-MINI-ISO_x86_64_remote_ssh_target_ftp">
+
+        <span id="res-584617">
+          <a href="/tests/584617">
+            <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+          </a>
+        </span>
+
+
+
+      </td>
+
+    </tr>
+    <tr>
+      <td class="name">remote_vnc_controller</td>
+
+      <td id="res_Gnome-MINI-ISO_x86_64_remote_vnc_controller">
+
+        <span id="res-584616">
+          <a href="/tests/584616">
+            <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+          </a>
+        </span>
+
+
+
+      </td>
+
+    </tr>
+    <tr>
+      <td class="name">remote_vnc_target_nfs</td>
+
+      <td id="res_Gnome-MINI-ISO_x86_64_remote_vnc_target_nfs">
+
+        <span id="res-584615">
+          <a href="/tests/584615">
+            <i class="status fa fa-circle result_passed" title="Done: passed"></i>
+          </a>
+        </span>
+
+
+
+      </td>
+
+    </tr>
+  </tbody>
+</table>
 </div>
 
-      </div>
+</div>
 
-      <footer class='footer'>
-        <div class='container'>
-          <div id='footer-legal' class="text-center">
-              openQA is licensed
-              <a href="https://github.com/os-autoinst/openQA">GPL-2.0</a>
-          </div>
-        </div>
-      </footer>
+<footer class='footer'>
+  <div class='container'>
+    <div id='footer-legal' class="text-center">
+      openQA is licensed
+      <a href="https://github.com/os-autoinst/openQA">GPL-2.0</a>
     </div>
-  </body>
+  </div>
+</footer>
+</div>
+</body>
 </html>

--- a/tests/tags_labels/report_link_new_issue/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
+++ b/tests/tags_labels/report_link_new_issue/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
@@ -298,7 +298,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="cryptlvm+activate_existing+force_recompute">cryptlvm+activate_existing ...</span></td>
+                        <td class="name"><span title="cryptlvm+activate_existing+force_recompute">cryptlvm+activate_existing+force_recompute</span></td>
 
                             <td id="res_Gnome-DVD_arm_cryptlvm+activate_existing+force_recompute">
 
@@ -310,7 +310,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="cryptlvm+activate_existing+import_users">cryptlvm+activate_existing ...</span></td>
+                        <td class="name"><span title="cryptlvm+activate_existing+import_users">cryptlvm+activate_existing+import_users</span></td>
 
                             <td id="res_Gnome-DVD_arm_cryptlvm+activate_existing+import_users">
 
@@ -622,7 +622,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2">rollback_upgrade_offline_13.2</span></td>
 
                             <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2">
 
@@ -634,7 +634,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline ...</span></td>
+                        <td class="name"><span title="rollback_upgrade_offline_13.2sp1">rollback_upgrade_offline_13.2sp1</span></td>
 
                             <td id="res_Gnome-DVD_arm_rollback_upgrade_offline_13.2sp1">
 
@@ -852,7 +852,7 @@
 
                     </tr>
                     <tr>
-                        <td class="name"><span title="yast_hostname+linuxrc_hostname">yast_hostname+linuxrc_host ...</span></td>
+                        <td class="name"><span title="yast_hostname+linuxrc_hostname">yast_hostname+linuxrc_hostname</span></td>
 
                             <td id="res_Gnome-DVD_arm_yast_hostname+linuxrc_hostname">
 

--- a/tests/tags_labels/report_link_new_issue/report25_bugrefs_bug_link_new_issue.md
+++ b/tests/tags_labels/report_link_new_issue/report25_bugrefs_bug_link_new_issue.md
@@ -13,6 +13,25 @@
 **Arch:** arm
 **Status: <span style="color: red;">Red</span>**
 
+**Skipped Test:**
+
+* RAID6
+* cryptlvm+activate_existing
+* cryptlvm+activate_existing+force_recompute
+* cryptlvm+activate_existing+import_users
+* cryptlvm+cancel_existing
+* installcheck
+* rollback_upgrade_offline_13.2
+* rollback_upgrade_offline_13.2sp1
+* gcc5-http
+* leap+extratests
+* xfs
+* yast_hostname
+* yast_hostname+linuxrc_hostname
+* yast_no_self_update
+
+
+
 **TODO: review**
 
 ***new issues***


### PR DESCRIPTION
Merging this patch the report will include listing skipped tests per architecture.  The results comes into the interesting_states dict which is store the state between the current and the previous job. however the skipped tests output considers only the current job and it does not attempt any comparison with the previous state( difference between the skipped tests)