### PR TITLE
Change syntax for colors to adapt to use of CommonMark

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -195,9 +195,9 @@ $url
 """)
 
 status_badge_str = {
-    'GREEN': '<span style="color: green;">Green</span>',
-    'AMBER': '<span style="color: #FFBF00;">Amber</span>',
-    'RED': '<span style="color: red;">Red</span>',
+    'GREEN': '{{color:#008000|Green}}',
+    'AMBER': '{{color:#FFBF00|Amber}}',
+    'RED': '{{color:#FF0000|Red}}',
 }
 
 
@@ -713,7 +713,7 @@ class Issue(object):
             if self.resolution:
                 status += ' (%s)' % self.resolution
             if status.startswith('VERIFIED') or status.startswith('Resolved'):
-                status = '<span style="color: red;">%s</span>' % status
+                status = '{{color:#FF0000|%s}}' % status
             msg = 'Ticket status: %s, prio/severity: %s, assignee: %s' % (status, self.priority, self.assignee)
         else:
             msg = None

--- a/tests/report25_T.md
+++ b/tests/report25_T.md
@@ -11,7 +11,7 @@
 ---
 
 **Arch:** x86_64
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/report25_TT.md
+++ b/tests/report25_TT.md
@@ -11,7 +11,7 @@
 ---
 
 **Arch:** x86_64
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/report25_TTT.md
+++ b/tests/report25_TTT.md
@@ -18,7 +18,7 @@
 ---
 
 **Arch:** x86_64
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/report25_terse.md
+++ b/tests/report25_terse.md
@@ -11,7 +11,7 @@
 ---
 
 **Arch:** x86_64
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report25_T_bugrefs.md
+++ b/tests/tags_labels/report25_T_bugrefs.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report25_T_bugrefs_softfails.md
+++ b/tests/tags_labels/report25_T_bugrefs_softfails.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report25_bugrefs.md
+++ b/tests/tags_labels/report25_bugrefs.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report25_bugrefs_abbreviated.md
+++ b/tests/tags_labels/report25_bugrefs_abbreviated.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report25_bugrefs_build1508.md
+++ b/tests/tags_labels/report25_bugrefs_build1508.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 
@@ -23,7 +23,7 @@
 **New openQA-issues:**
 
 * toolchain_zypper -> [poo#13694](https://progress.opensuse.org/issues/13694) (Request to https://progress.opensuse.org/issues/13694.json was not successful, file https%3A::progress.opensuse.org:issues:13694.json not found)
-* allpatterns2@i586--l2 -> [poo#9773](https://progress.opensuse.org/issues/9773 "Nothing works ✓") (Ticket status: <span style="color: red;">Resolved</span>, prio/severity: High, assignee: None)
+* allpatterns2@i586--l2 -> [poo#9773](https://progress.opensuse.org/issues/9773 "Nothing works ✓") (Ticket status: {{color:#FF0000|Resolved}}, prio/severity: High, assignee: None)
 
 
 **Existing openQA-issues:**

--- a/tests/tags_labels/report25_bugrefs_query_issues.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report25_bugrefs_query_issues_filter_closed.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues_filter_closed.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues_filter_unassigned.md
@@ -7,7 +7,7 @@
 ---
 
 **Arch:** i586
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 

--- a/tests/tags_labels/report_link_new_issue/report25_bugrefs_bug_link_new_issue.md
+++ b/tests/tags_labels/report_link_new_issue/report25_bugrefs_bug_link_new_issue.md
@@ -11,7 +11,7 @@
 ---
 
 **Arch:** arm
-**Status: <span style="color: red;">Red</span>**
+**Status: {{color:#FF0000|Red}}**
 
 **Skipped Test:**
 


### PR DESCRIPTION
This should only be merged if the upcoming Markdown change in openQA is merged and deployed.