### PR TITLE
Fix error on repeated test modules when reading out details from soft-fail bugrefs

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -905,7 +905,7 @@ class ArchReport(object):
         details_json = json.loads(self.test_browser.get_soup('%s/file/details-%s.json' % (result_item['href'], module_name)).getText())
         for field in details_json:
             if 'title' in field and 'Soft Fail' in field['title']:
-                unformated_str = self.test_browser.get_soup('%s/file/%s' % (result_item['href'], field['text'])).getText()
+                unformated_str = self.test_browser.get_soup('%s/file/%s' % (result_item['href'], quote(field['text']))).getText()
                 return re.search('Soft Failure:\n(.*)', unformated_str.strip()).group(1)
             elif 'properties' in field and len(field['properties']) > 0 and field['properties'][0] == 'workaround':
                 log.debug("Evaluating potential workaround needle '%s'" % field['needle'])


### PR DESCRIPTION
Test module names have an appended "#<nr>" when scheduled multiple
times. By quoting the names accordingly we generate valid URLs.

Tested locally with

```
openqa_review/openqa_review.py -vvvv -J http://openqa.suse.de/group_overview/265 -TTTTT -R -r --include-softfails -n --arch s390x
```