### PR TITLE
Read text data from details JSON if present

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -913,7 +913,10 @@ class ArchReport(object):
         details = details_json['details'] if 'details' in details_json else details_json
         for field in details:
             if 'title' in field and 'Soft Fail' in field['title']:
-                unformated_str = self.test_browser.get_soup('%s/file/%s' % (result_item['href'], quote(field['text']))).getText()
+                if 'text_data' in field:
+                    unformated_str = field['text_data']
+                else:
+                    unformated_str = self.test_browser.get_soup('%s/file/%s' % (result_item['href'], quote(field['text']))).getText()
                 return re.search('Soft Failure:\n(.*)', unformated_str.strip()).group(1)
             elif 'properties' in field and len(field['properties']) > 0 and field['properties'][0] == 'workaround':
                 log.debug("Evaluating potential workaround needle '%s'" % field['needle'])

--- a/tests/tags_labels/:tests:684839:file:details-zypper_info.json
+++ b/tests/tags_labels/:tests:684839:file:details-zypper_info.json
@@ -10,6 +10,7 @@
       "result": "unk"
     },
     "title": "Soft Failed",
-    "text": "zypper_info-4.txt"
+    "text": "zypper_info-4.txt",
+    "text_data": "# Soft Failure:\nfor Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for https://progress.opensuse.org/issues/36256 to be solved, and also http://fate.suse.com/12345 ✓"
   }
 ]

--- a/tests/tags_labels/:tests:684839:file:zypper_info-4.txt
+++ b/tests/tags_labels/:tests:684839:file:zypper_info-4.txt
@@ -1,2 +1,0 @@
-# Soft Failure:
-for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for https://progress.opensuse.org/issues/36256 to be solved, and also http://fate.suse.com/12345 ✓


### PR DESCRIPTION
This change is necessary due to changes on the openQA side. The text file might not be available anymore. Its content is instead directly incorporated into the details JSON document.

See https://progress.opensuse.org/issues/69058#note-1

---

Let's see whether the CI checks still pass. I had troubles running the tests locally. At least `python3 openqa_review/openqa_review.py -vvvv -n -r -T --no-empty-sections --include-softfails -J https://openqa.suse.de/group_overview/290` shows no 404 errors anymore.