### PR TITLE
Fix "ValueError: Expecting ',' delimiter: line 1..." when trying to parse soft-fail details

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -909,7 +909,7 @@ class ArchReport(object):
     def _get_bugref_for_softfailed_module(self, result_item, module_name):
         details_url = '%s/file/details-%s.json' % (result_item['href'], module_name)
         log.debug("Retrieving '%s'" % details_url)
-        details_json = json.loads(self.test_browser.get_soup(details_url).getText())
+        details_json = self.test_browser.get_json(details_url)
         details = details_json['details'] if 'details' in details_json else details_json
         for field in details:
             if 'title' in field and 'Soft Fail' in field['title']:


### PR DESCRIPTION
This problem happened since about a month during every run but only on
openqa.suse.de data as it seems. The problem was caused by a lot of
escaped text in test module details in conjunction with our code trying
to parse the json document as text first and then parsing as JSON when
escaped characters are already evaluated by python when they should not
have been touched at all. Better we use the `get_json` method of our
browser objects directly to prevent this.