### PR TITLE
Fix readout of custom softfail references

### DIFF
--- a/tests/tags_labels/:tests:1316928
+++ b/tests/tags_labels/:tests:1316928
@@ -1,0 +1,20 @@
+<tr>
+    <td class="component">
+        <div>
+            <a href="/tests/1316928/modules/shutdown/steps/1/src">shutdown</a>
+        </div>
+        <div class="flags">
+        </div>
+    </td>
+    <td class="result resultsoftfailed">
+        soft-failed
+    </td>
+    <td class="links">
+        <div class="links_a">
+            <div class="fa fa-caret-up"></div>
+            <a class="no_hover" data-url="/tests/1316928/modules/shutdown/steps/9" href="#step/shutdown/9"
+               title="Soft Failed">
+                <span class="resborder resborder_hash(0x9c726c8)">Soft Failed</span>
+            </a></div>
+    </td>
+</tr>

--- a/tests/tags_labels/:tests:1316928:file:details-shutdown.json
+++ b/tests/tags_labels/:tests:1316928:file:details-shutdown.json
@@ -1,0 +1,2 @@
+{"dents": 0, "details": [{"result": "softfail", "text": "shutdown-9.txt", "title": "rogue workqueue lockup boo#1126782"}], "result": "softfail"}
+

--- a/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
+++ b/tests/tags_labels/:tests:overview%3Fdistri%3Dopensuse%26version%3D42.1%26build%3D1507%26groupid%3D25
@@ -2866,6 +2866,21 @@
                                 <td>-</td>
 
                     </tr>
+
+                    <tr>
+                        <td class="name">custom_bugref</td>
+                                <td>-</td>
+                                <td>-</td>
+                            <td id="res_Gnome-DVD-i586_custom_bugref">
+                         <span id="res-1316928">
+                             <a href="/tests/1316928">
+                                 <i class="status fa fa-circle result_softfailed" title="Done: softfail"></i>
+                             </a>
+                         </span>
+            </td>
+<td>-</td>
+</tr>
+
                     <tr>
                         <td class="name"><span title="leap12_minimal_base+gcc5_create_hdd">leap12_minimal_base+gcc5_cr ...</span></td>
 

--- a/tests/tags_labels/report25_T_bugrefs_softfails.md
+++ b/tests/tags_labels/report25_T_bugrefs_softfails.md
@@ -11,6 +11,7 @@
 
 **New Product bugs:**
 
+* soft fails: [custom_bugref](https://openqa.opensuse.org/tests/1316928) -> [boo#1126782](https://bugzilla.opensuse.org/show_bug.cgi?id=1126782)
 * [toolchain_zypper](https://openqa.opensuse.org/tests/384324 "Failed modules: install") -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571)
 * [toolchain_zypper@bar](https://openqa.opensuse.org/tests/3843245 "Failed modules: install") -> [boo#9315715](https://bugzilla.opensuse.org/show_bug.cgi?id=9315715)
 * soft fails: [create_hdd_textmode](https://openqa.opensuse.org/tests/447901) -> [boo#931572](https://bugzilla.opensuse.org/show_bug.cgi?id=931572)

--- a/tests/tags_labels/report25_bugrefs_query_issues.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues.md
@@ -11,6 +11,7 @@
 
 **New Product bugs:**
 
+* soft fails: custom_bugref -> [boo#1126782](https://bugzilla.opensuse.org/show_bug.cgi?id=1126782) (Request to /jsonrpc.cgi?method=Bug.get&params=%5B%7B%22ids%22%3A+%5B1126782%5D%7D%5D was not successful, file :jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B1126782%255D%257D%255D not found)
 * toolchain_zypper -> [boo#931571](https://bugzilla.opensuse.org/show_bug.cgi?id=931571 "no space left on device when upgrading ✓") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)
 * toolchain_zypper@bar -> [boo#9315715](https://bugzilla.opensuse.org/show_bug.cgi?id=9315715) (Ticket not found)
 * soft fails: create_hdd_textmode -> [boo#931572](https://bugzilla.opensuse.org/show_bug.cgi?id=931572 "no space left on device when upgrading ✓") (Ticket status: NEW, prio/severity: P2/Major, assignee: kernel-maintainers@forge.provo.novell.com)


### PR DESCRIPTION
Reproduced a problem observed in production locally with:

```
mkdir tmp_no_found_softfail_ref
python3 openqa_review/openqa_review.py -J https://openqa.opensuse.org/group_overview/50 --arch x86_64 -vv -TTTT --include-softfails --bugrefs --no-empty-sections --save --save-dir tmp_no_found_softfail_ref
python3 openqa_review/openqa_review.py -J https://openqa.opensuse.org/group_overview/50 --arch x86_64 -vv -TTTT --include-softfails --bugrefs --no-empty-sections --load --load-dir tmp_no_found_softfail_ref
```