### PR TITLE
Change comments to not private when adding comments

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -667,7 +667,7 @@ class Issue(object):
             self.bugzilla_browser.json_rpc_post('/jsonrpc.cgi', 'Bug.add_comment', {
                 'id': self.bugid,
                 'comment': comment,
-                'is_private': True,
+                'is_private': False,
             })
         # self.issue_type == 'redmine':
         else:


### PR DESCRIPTION
The username `openqa_review` doesn't have permission to add a private
comment to Bugzilla. And `openqa_review` only can get the public
comments from Bugzilla. So when adding a private comment, Bugzilla will
return an error `500 Server Error: Internal Server Error`.

Test result: https://bugzilla.suse.com/show_bug.cgi?id=1005824

See: https://progress.opensuse.org/issues/75214