### PR TITLE
Consistently use openqa_review from its own installation

### DIFF
--- a/bin/dashboard
+++ b/bin/dashboard
@@ -5,11 +5,7 @@
 
 TPL="${TPL:-"dashboard_files/dashboard.html.in"}"
 OUT="${OUT:-"dashboard.html"}"
-if command -v openqa-review >/dev/null ; then
-    OPENQA_REVIEW="${OPENQA_REVIEW:-"openqa-review"}"
-else
-    OPENQA_REVIEW="${OPENQA_REVIEW:-"./openqa_review/openqa_review.py"}"
-fi
+OPENQA_REVIEW="${OPENQA_REVIEW:-"./openqa_review/openqa_review.py"}"
 
 openqa_host="${openqa_host:-"http://openqa.suse.de/"}"
 

--- a/bin/openqa-review-daily-email
+++ b/bin/openqa-review-daily-email
@@ -18,7 +18,7 @@ openqa_review_html_args="${openqa_review_html_args:-"${load_args}"}"
 # and if we call it here and also in a later step we would end up with
 # duplicate reminder comments
 openqa_review_save_args="${openqa_review_save_args:-"--reminder-comment-on-issues --save --save-dir ${tmp}"}"
-openqa_review="${openqa_review:-"$(command -v openqa-review)"}"
+openqa_review="${openqa_review:-"./openqa_review/openqa_review.py"}"
 TPL="${TPL:-"$(dirname $0)/../dashboard_files/dashboard.html.in"}"
 # We have to preserve the '$@' until here to prevent too early evaluation of parameters with spaces
 save_report="$(${openqa_review} ${openqa_review_args} ${openqa_review_save_args} "$@")"


### PR DESCRIPTION
Otherwise we end up trying to run from a git clone and getting some of the code from git and some from what happens to be installed.

See: https://progress.opensuse.org/issues/75214