### PR TITLE
Specify Loader=yaml.SafeLoader explicitly

### DIFF
--- a/openqa_review/tumblesle_release.py
+++ b/openqa_review/tumblesle_release.py
@@ -250,7 +250,7 @@ class TumblesleRelease(object):
             raise NotImplementedError("tag check not implemented")
         elif self.args.check_against_build == "release_info":
             with open(self.release_info_path, "r") as release_info_file:
-                release_info = yaml.load(release_info_file)
+                release_info = yaml.load(release_info_file, Loader=yaml.SafeLoader)
                 build["released"] = release_info[self.args.product]["build"]
         else:
             build["released"] = self.args.check_against_build


### PR DESCRIPTION
Otherwise the following deprecation warning is visible:

    tests/test_tumblesle_release.py::test_compare_old_released_with_release_info_against_new_good_yields_release
      $PWD/.tox/py38/lib/python3.8/site-packages/openqa_review/tumblesle_release.py:253: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    release_info = yaml.load(release_info_file)