### PR TITLE
Fix relative import path for directly called testsuite

### DIFF
--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -21,12 +21,14 @@ import sys
 import tempfile
 from argparse import Namespace
 from builtins import str
-from openqa_review.browser import filename_to_url
 from urllib.parse import urljoin, urlparse
 from configparser import ConfigParser  # isort:skip can not make isort happy here
 
 import pytest
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from openqa_review.browser import filename_to_url
 from openqa_review import openqa_review  # SUT
 
 


### PR DESCRIPTION
This will prevent confusion when the testsuite tries to
import the system wide installed `openqa_review` or fail
when called directly or with `py.test` insted of `tox`.