### PR TITLE
Improve handling of --filter

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -1521,12 +1521,11 @@ def main():  # pragma: no cover, only interactive
         reminder_comment_on_issues(report)
 
     if args.filter:
-        try:
-            filter_report(report, ie_filters[args.filter])
-        except KeyError:
+        if args.filter not in ie_filters:
             print("No such filter '%s'" % args.filter)
             print("Available filters: %s" % ", ".join(ie_filters.keys()))
             sys.exit(1)
+        filter_report(report, ie_filters[args.filter])
 
     try:
         print(report)


### PR DESCRIPTION
Currently a KeyError is catched, but that might be also a KeyError
happening inside filter_report().

For developers this can lead to such a confusing error message:

    No such filter 'unassigned'
    Available filters: closed, unassigned

Since we can easily check if a key exists in a dict, we don't need
exception handling for that.