### PR TITLE
Fix loading bug info for hashless bugrefs

### DIFF
--- a/tests/tags_labels/:tests:384330:file:select_patterns_and_packages-125.txt
+++ b/tests/tags_labels/:tests:384330:file:select_patterns_and_packages-125.txt
@@ -1,2 +1,2 @@
 # Soft Failure:
-Some text to make parsing more interesting - bsc#1029660
+Some text to make parsing more interesting - bsc1029660

--- a/tests/tags_labels/report25_T_bugrefs_softfails.md
+++ b/tests/tags_labels/report25_T_bugrefs_softfails.md
@@ -20,8 +20,8 @@
 
 **Existing Product bugs:**
 
-* soft fails: [btrfs](https://openqa.opensuse.org/tests/384330), [zfcp@i586-zfcp](https://openqa.opensuse.org/tests/384707) -> [bsc#1029660](https://bugzilla.suse.com/show_bug.cgi?id=1029660)
 * [allpatterns](https://openqa.opensuse.org/tests/384333 "Failed modules: xterm"), [ext4@i586--l2](https://openqa.opensuse.org/tests/384634 "Failed modules: install_and_reboot"), [gnome](https://openqa.opensuse.org/tests/384344 "Failed modules: xterm"), [minimal+base](https://openqa.opensuse.org/tests/384329 "Failed modules: dns_srv") -> [bsc#822770](https://bugzilla.opensuse.org/show_bug.cgi?id=822770)
+* soft fails: [btrfs](https://openqa.opensuse.org/tests/384330), [zfcp@i586-zfcp](https://openqa.opensuse.org/tests/384707) -> [bsc1029660](https://bugzilla.suse.com/show_bug.cgi?id=1029660)
 
 
 **Existing openQA-issues:**

--- a/tests/tags_labels/report25_bugrefs_query_issues.md
+++ b/tests/tags_labels/report25_bugrefs_query_issues.md
@@ -20,8 +20,8 @@
 
 **Existing Product bugs:**
 
-* soft fails: btrfs, zfcp@i586-zfcp -> [bsc#1029660](https://bugzilla.suse.com/show_bug.cgi?id=1029660) (Request to /jsonrpc.cgi?method=Bug.get&params=%5B%7B%22ids%22%3A+%5B1029660%5D%7D%5D was not successful, file :jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B1029660%255D%257D%255D not found)
 * allpatterns, ext4@i586--l2, gnome, minimal+base -> [bsc#822770](https://bugzilla.opensuse.org/show_bug.cgi?id=822770 "Install of grub2-efi failed") (Ticket status: RESOLVED (FOOBAR), prio/severity: P5/Normal, assignee: bazifoo@gmail.com)
+* soft fails: btrfs, zfcp@i586-zfcp -> [bsc1029660](https://bugzilla.suse.com/show_bug.cgi?id=1029660) (Request to /jsonrpc.cgi?method=Bug.get&params=%5B%7B%22ids%22%3A+%5B1029660%5D%7D%5D was not successful, file :jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B1029660%255D%257D%255D not found)
 
 
 **Existing openQA-issues:**


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/93724

Bugrefs eg bsc1234 instead bsc#1234 happen eg when using
softfail needles as filenames don't contain hashes.