### PR TITLE
Raise HTTP status errors in browser content

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -144,6 +144,7 @@ class Browser(object):
             log.warn(msg)
             raise DownloadError(msg)
 
+        r.raise_for_status()
         content = r.json() if as_json else r.content.decode("utf8")
         return content
 


### PR DESCRIPTION
In other functions we also uses raise_for_status, which is an optional mechanism to get exceptions for failed requests.

See: https://progress.opensuse.org/issues/93943