### PR TITLE
Ensure that the progress api key is always provided via header

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -333,11 +333,8 @@ def absolute_url(root, v):
 def progress_browser_factory(args):
     return Browser(
         args,
-        "",
-        auth=(
-            config.get("test_issues", "api_key"),
-            "foobar",
-        ),
+        root_url="",
+        headers={"X-Redmine-API-Key": config.get("test_issues", "api_key")},
     )
 
 


### PR DESCRIPTION
The old way passing it via BASIC auth doesn't work anymore

Ticket: https://progress.opensuse.org/issues/93943