### PR TITLE
Catch HTTPError and raise DownloadError

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -145,7 +145,13 @@ class Browser(object):
             log.warn(msg)
             raise DownloadError(msg)
 
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            msg = "Request to {} failed: {}".format(url, str(e))
+            log.warn(msg)
+            raise DownloadError(msg)
+
         content = r.json() if as_json else r.content.decode("utf8")
         return content
 


### PR DESCRIPTION
This can mean a request failed with a 404:

    Request to https://openqa.suse.de/tests/5989057/file/details-bootloader_zkvm#1.json failed:
    404 Client Error: Not Found for url: https://openqa.suse.de/tests/5989061/file/details-bootloader_zkvm#1.json

We should regard this as an error to be reviewed manually in the generated report. The URL will be visible there and we can still continue with the generation of the report.

See: https://progress.opensuse.org/issues/93943

### Manual reproducer:

    python3 openqa_review/openqa_review.py --host https://openqa.suse.de -n -r -T --query-issue-status --no-empty-sections --include-softfails --running-threshold=2 --exclude-job-groups '^(Released|Development|old|EOL)' -J https://openqa.suse.de/group_overview/143

This should include the above error message without raising an exception.