### PR TITLE
Bump timeout for individual browser.get requests

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -116,7 +116,7 @@ class Browser(object):
         http.mount("{}://".format(parsed_url.scheme), HTTPAdapter(max_retries=retries))
 
         try:
-            r = http.get(url, auth=self.auth, timeout=2.5, headers=self.headers)
+            r = http.get(url, auth=self.auth, timeout=10, headers=self.headers)
         except requests.exceptions.SSLError as e:
             try:
                 import OpenSSL


### PR DESCRIPTION
The timeout of 2.5 seconds is too low for when OSD is under heavy load. Testing at different times during the day suggests 10 is much better.

### Manual reproducer:

Run this repeatedly. When OSD is under high load there's a lot of timeouts and it may not catch up even after 7 attempts with the current timeout.

    python3 openqa_review/openqa_review.py --host https://openqa.suse.de -n -r -T --query-issue-status --no-empty-sections --include-softfails --run

See: https://progress.opensuse.org/issues/93943