### PR TITLE
Improve handling of unknown or unexpected bugrefs

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -282,8 +282,10 @@ def get_test_bugref(entry):
     bugref = entry.find(id=re.compile("^bug-"))
     if not bugref:
         return {}
+    reference = re.search(r"\S+#([0-9]+)", bugref.i["title"])
+    reference = reference.group() if reference else "(unknown bugref in %s)" % bugref.i["title"]
     # work around openQA providing incorrect URLs (e.g. following whitespace)
-    return {"bugref": re.search(r"\S+#([0-9]+)", bugref.i["title"]).group(), "bugref_href": bugref.a["href"].strip()}
+    return {"bugref": reference, "bugref_href": bugref.a["href"].strip()}
 
 
 def get_state(cur, prev_dict):


### PR DESCRIPTION
e.g. `jsc#ABC-123`

Issue: https://progress.opensuse.org/issues/95989

Additionally improve logging in case the regex does not match, so that
we immediately see what didn't match and why.

If necessary, I will try to add a test, but will be afk for a few hours and wanted to push a fix ASAP.