### PR TITLE
Increase browser.get timeout from 10 to 30

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -116,7 +116,7 @@ class Browser(object):
         http.mount("{}://".format(parsed_url.scheme), HTTPAdapter(max_retries=retries))
 
         try:
-            r = http.get(url, auth=self.auth, timeout=10, headers=self.headers)
+            r = http.get(url, auth=self.auth, timeout=30, headers=self.headers)
         except requests.exceptions.SSLError as e:
             try:
                 import OpenSSL


### PR DESCRIPTION
Observing [pipeline runs on internal GitLab](https://gitlab.suse.de/openqa/openqa-review/-/pipelines/184191) I saw several timeouts. So attempting to remedy that by increasing from `10s` to `30s`. Not sure we can do much else here.