### PR TITLE
Handle ChunkedEncodingError in browser.get

### DIFF
--- a/openqa_review/browser.py
+++ b/openqa_review/browser.py
@@ -144,6 +144,10 @@ class Browser(object):
             msg = "Request to {} was not successful after {} retries: {}".format(url, retries.total, str(e))
             log.warn(msg)
             raise DownloadError(msg)
+        except requests.exceptions.ChunkedEncodingError as e:
+            msg = "Request to {} was not successful: {}".format(url, str(e))
+            log.warn(msg)
+            raise DownloadError(msg)
 
         try:
             r.raise_for_status()


### PR DESCRIPTION
In this case we can't recover, but we can still log the error and continue with other reports.

See: https://progress.opensuse.org/issues/97856