### PR TITLE
Change job groups in todo_only report into section headers

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -1464,7 +1464,7 @@ class Report(object):
                 if not len(generated):
                     continue
                 report_str += (
-                    "* %s:\n%s" % (k, generated) if self.args.todo_only else "# %s\n\n%s\n---\n" % (k, generated)
+                    "### %s:\n%s" % (k, generated) if self.args.todo_only else "# %s\n\n%s\n---\n" % (k, generated)
                 )
         return report_str
 

--- a/tests/todo-only/report-todo-only.md
+++ b/tests/todo-only/report-todo-only.md
@@ -1,5 +1,5 @@
 **TODO: review**
 
-* 1:
+### 1:
 * **existing** [openqa_from_containers](https://openqa.opensuse.org/tests/1841487 "Failed modules: search") [(ref)](https://openqa.opensuse.org/tests/1840980 "Previous test")
 * **existing** [openqa_from_git](https://openqa.opensuse.org/tests/1841489 "Failed modules: search") [(ref)](https://openqa.opensuse.org/tests/1840982 "Previous test")


### PR DESCRIPTION
Change job groups from list items to section headings for readability 
Corresponding Ticket: https://progress.opensuse.org/issues/97403