### PR TITLE
Document how to locally test

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,29 @@ all environments:
 tox
 ```
 
-Or you can run the tests via pytest:
+Or you can run the tests via pytest with one of the following commands:
 
 ```
 pytest
+# or
+python3 -m pytest
+# or, after running tox at least once:
+./.tox/cov/bin/py.test
+```
+
+To get a coverage report, do:
+
+```
+tox -e cov
+./.tox/cov/bin/coverage html
+```
+
+Then you will find a coverage report under `coverage_html/`.
+
+To test only certain functions, there are several possibilities:
+```
+pytest tests/test_openqa_review.py::test_reminder_comments_on_referenced_bugs_are_posted
+pytest -k test_reminder_comments_on_referenced_bugs_are_posted
 ```
 
 ### Rules for commits


### PR DESCRIPTION
When trying to generate a coverage report, I got an error message:
```
tox -e cov
coverage html
Couldn't read data from '.../openqa_review/.coverage': UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 106: invalid start byte
```
So it's important to run the correct binary compatible with the one that generated the data.