### PR TITLE
Improve logging of TypeError

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -94,6 +94,7 @@ import logging
 import os.path
 import re
 import sys
+import traceback
 from builtins import str
 from collections import defaultdict, OrderedDict
 from configparser import ConfigParser, NoSectionError, NoOptionError  # isort:skip can not make isort happy here
@@ -701,7 +702,10 @@ class Issue(object):
                 self.msg = str(e)
                 self.error = True
             except TypeError as e:
-                log.error("Error retrieving details for bugref %s (%s): %s" % (self.bugref, self.bugref_href, e))
+                log.error(
+                    "Error retrieving details for bugref %s (%s): %s\n%s"
+                    % (self.bugref, self.bugref_href, e, traceback.format_exc())
+                )
                 self.msg = "Ticket not found"
                 self.error = True
 


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/102200

So far we only see:

    ERROR:openqa_review.openqa_review:Error retrieving details for bugref
    boo#1183044 (https://bugzilla.opensuse.org/show_bug.cgi?id=1183044):
    'NoneType' object is not subscriptable

so we don't know where that exception actually happened.

This commit adds a traceback to the message.

I couldn't reproduce the issue locally so far, but adding the traceback might help us when it happens next time in production.