### PR TITLE
Handle bugzilla jsonrpc errors

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -108,7 +108,7 @@ from sortedcontainers import SortedDict
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from openqa_review.browser import Browser, DownloadError, add_load_save_args  # isort:skip
+from openqa_review.browser import Browser, DownloadError, BugNotFoundError, add_load_save_args  # isort:skip
 
 
 # treat humanfriendly as optional dependency
@@ -701,7 +701,7 @@ class Issue(object):
                 )
                 self.msg = str(e)
                 self.error = True
-            except TypeError as e:
+            except BugNotFoundError as e:
                 log.error(
                     "Error retrieving details for bugref %s (%s): %s\n%s"
                     % (self.bugref, self.bugref_href, e, traceback.format_exc())

--- a/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B9315715%255D%257D%255D
+++ b/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B9315715%255D%257D%255D
@@ -1,0 +1,1 @@
+{"error":{"message":"Bug #9315715 does not exist.","code":101},"id":"https://bugzilla.suse.com/","result":null}

--- a/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B9315716%255D%257D%255D
+++ b/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B9315716%255D%257D%255D
@@ -1,0 +1,1 @@
+{"error":{"message":"The username or password you entered is not valid.","code":300},"id":"https://bugzilla.suse.com/","result":null}


### PR DESCRIPTION
Bugs not found are non-fatal and should be shown in the generated HTML,
but authentication errors should be fatal.

Issue: https://progress.opensuse.org/issues/102200

TODO: test