### PR TITLE
Add GitHub Workflow for testing

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,0 +1,79 @@
+name: Test
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest tox pytest-mock
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - run: env | sort
+
+    - name: test
+      run: |
+        PYTHONVERSION=${{ matrix.python-version }}
+        tox -e py"${PYTHONVERSION/./}"
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest tox pytest-mock
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - run: |
+        tox -e cov
+        ./.tox/cov/bin/coverage html
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: coverage_html/
+
+  style:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest tox pytest-mock
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - run: tox -e doctests || true   # not yet working
+    - run: tox -e flake8
+    - run: tox -e black


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/102350

What's not yet working: doctests
```
.tox/cov/bin/py.test --doctest-modules openqa_review                                                                                                                [p5.26.3] 20:01:45
============================================================================================================= test session starts ==============================================================================================================
platform linux -- Python 3.6.12, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/tina/openqa-devel/repos/openqa_review
plugins: mock-3.6.1, cov-2.12.0
collected 2 items / 2 errors                                                                                                                                                                                                                   

==================================================================================================================== ERRORS ====================================================================================================================
_______________________________________________________________________________________________ ERROR collecting openqa_review/openqa_review.py ________________________________________________________________________________________________
openqa_review/openqa_review.py:111: in <module>
    from openqa_review.browser import Browser, DownloadError, add_load_save_args  # isort:skip
E   ModuleNotFoundError: No module named 'openqa_review.browser'
_____________________________________________________________________________________________ ERROR collecting openqa_review/tumblesle_release.py ______________________________________________________________________________________________
openqa_review/tumblesle_release.py:42: in <module>
    from openqa_review.browser import Browser, add_load_save_args
E   ModuleNotFoundError: No module named 'openqa_review.browser'
=========================================================================================================== short test summary info ============================================================================================================
ERROR openqa_review/openqa_review.py - ModuleNotFoundError: No module named 'openqa_review.browser'
ERROR openqa_review/tumblesle_release.py - ModuleNotFoundError: No module named 'openqa_review.browser'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================================================== 2 errors in 0.37s ===============================================================================================================
```
I tried to set PYTHONPATH to `.` or `openqa_review`, nothing helped.


Here you can see the test run: https://github.com/perlpunk/openqa_review/actions/runs/1454372644

It has first to be merged to master, then the following pull requests will be tested automatically.