### PR TITLE
Prevent assertion when querying the last issue comment

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -752,9 +752,10 @@ class Issue(object):
                     "is_private": False,
                 },
             )
-        # self.issue_type == 'redmine':
-        else:
+        elif self.issue_type == "redmine":
             self.progress_browser.json_rest(self.bugref_href + ".json", "PUT", {"issue": {"notes": comment}})
+        else:
+            assert False, "Only bugzilla or redmine supported as issue type"
 
     @property
     def is_assigned(self):

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -781,8 +781,7 @@ class Issue(object):
     @property
     def last_comment(self):
         """Return datetime object and text of last comment retrieved from an issue."""
-        if not self.last_comment_date or self.last_comment_text is None:
-            assert self.issue_type == "bugzilla"
+        if self.issue_type == "bugzilla" and (self.last_comment_date is None or self.last_comment_text is None):
             res = self.bugzilla_browser.json_rpc_get("/jsonrpc.cgi", "Bug.comments", {"ids": [self.bugid]})
             comments = res["result"]["bugs"][str(self.bugid)]["comments"]
             self.last_comment_date = datetime.datetime.strptime(comments[-1]["creation_time"], "%Y-%m-%dT%H:%M:%SZ")
@@ -1536,7 +1535,7 @@ def reminder_comment_on_issue(ie, min_days_unchanged=MIN_DAYS_UNCHANGED):
     issue = ie.bug
     if issue.error:
         return
-    if not issue.issue_type:
+    if not issue.issue_type or issue.error:
         return
     (last_comment_date, last_comment_text) = issue.last_comment
     if (datetime.datetime.utcnow() - last_comment_date).days >= min_days_unchanged:

--- a/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.comments%26params%3D%255B%257B%2522ids%2522%253A%2B%255B815%255D%257D%255D
+++ b/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.comments%26params%3D%255B%257B%2522ids%2522%253A%2B%255B815%255D%257D%255D
@@ -1,0 +1,1 @@
+{"result":{"bugs":{"815":{"comments":[{"text":"some bugzilla comment"},{"creation_time":"2021-11-15T00:00:00Z","text":"most recent bugzilla comment"}]}}}}

--- a/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B0815%255D%257D%255D
+++ b/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B0815%255D%257D%255D
@@ -1,0 +1,1 @@
+{"id":"https://bugzilla.suse.com/","result":null}

--- a/tests/progress/https%3A::progress.opensuse.org:issues:102440.json%3Finclude%3Djournals
+++ b/tests/progress/https%3A::progress.opensuse.org:issues:102440.json%3Finclude%3Djournals
@@ -1,0 +1,1 @@
+{"issue":{"status":{"name":"foo"},"subject":"bar","priority":{"name":"urgent"},"updated_on":"2021-11-15T00:00:00Z","journals":[{"notes":"first progress note"},{"notes":"latest progress note"}]}}

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -630,27 +630,20 @@ def test_browser_decode_content():
         assert "Unable to decode JSON" in str(e)
 
 
+def issue_factory(bugref, bugref_href, args):
+    browser = browser_factory(args)
+    return openqa_review.Issue(bugref, bugref_href, True, browser, browser)
+
+
 def test_get_bugzilla_issue():
     args = cache_test_args_factory()
     args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bugzilla")
     browser = browser_factory(args)
-    issue = openqa_review.Issue(
-        "boo#9315715",
-        "https://bugzilla.opensuse.org/show_bug.cgi?id=9315715",
-        True,
-        browser,
-        browser,
-    )
+    issue = issue_factory("boo#9315715", "https://bugzilla.opensuse.org/show_bug.cgi?id=9315715", args)
     assert str(issue) == "[boo#9315715](https://bugzilla.opensuse.org/show_bug.cgi?id=9315715) (Ticket not found)"
 
     try:
-        issue = openqa_review.Issue(
-            "boo#9315716",
-            "https://bugzilla.opensuse.org/show_bug.cgi?id=9315716",
-            True,
-            browser,
-            browser,
-        )
+        issue_factory("boo#9315716", "https://bugzilla.opensuse.org/show_bug.cgi?id=9315716", args)
     except BugzillaError as e:
         assert e.message == "The username or password you entered is not valid."
         assert e.code == 300
@@ -659,15 +652,7 @@ def test_get_bugzilla_issue():
 def test_querying_last_bugzilla_comment():
     args = cache_test_args_factory()
     args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bugzilla")
-    browser = browser_factory(args)
-
-    issue = openqa_review.Issue(
-        "boo#0815",
-        "https://bugzilla.opensuse.org/show_bug.cgi?id=0815",
-        True,
-        browser,
-        browser,
-    )
+    issue = issue_factory("boo#0815", "https://bugzilla.opensuse.org/show_bug.cgi?id=0815", args)
     (comment_date, comment_text) = issue.last_comment
     assert str(comment_date) == "2021-11-15 00:00:00", "creation time read"
     assert comment_text == "most recent bugzilla comment", "most recent comment returned"
@@ -676,14 +661,7 @@ def test_querying_last_bugzilla_comment():
 def test_querying_last_progress_comment():
     args = cache_test_args_factory()
     args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "progress")
-    browser = browser_factory(args)
-    issue = openqa_review.Issue(
-        "poo#102440",
-        "https://progress.opensuse.org/issues/102440",
-        True,
-        browser,
-        browser,
-    )
+    issue = issue_factory("poo#102440", "https://progress.opensuse.org/issues/102440", args)
     (comment_date, comment_text) = issue.last_comment
     assert str(comment_date) == "2021-11-15 00:00:00", "creation time read"
     assert comment_text == "latest progress note", "most recent comment returned"

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -655,6 +655,7 @@ def test_get_bugzilla_issue():
         assert e.message == "The username or password you entered is not valid."
         assert e.code == 300
 
+
 def test_querying_last_bugzilla_comment():
     args = cache_test_args_factory()
     args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bugzilla")
@@ -669,3 +670,20 @@ def test_querying_last_bugzilla_comment():
     )
     (comment_date, comment_text) = issue.last_comment
     assert str(comment_date) == "2021-11-15 00:00:00", "creation time read"
+    assert comment_text == "most recent bugzilla comment", "most recent comment returned"
+
+
+def test_querying_last_progress_comment():
+    args = cache_test_args_factory()
+    args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "progress")
+    browser = browser_factory(args)
+    issue = openqa_review.Issue(
+        "poo#102440",
+        "https://progress.opensuse.org/issues/102440",
+        True,
+        browser,
+        browser,
+    )
+    (comment_date, comment_text) = issue.last_comment
+    assert str(comment_date) == "2021-11-15 00:00:00", "creation time read"
+    assert comment_text == "latest progress note", "most recent comment returned"

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -654,3 +654,18 @@ def test_get_bugzilla_issue():
     except BugzillaError as e:
         assert e.message == "The username or password you entered is not valid."
         assert e.code == 300
+
+def test_querying_last_bugzilla_comment():
+    args = cache_test_args_factory()
+    args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bugzilla")
+    browser = browser_factory(args)
+
+    issue = openqa_review.Issue(
+        "boo#0815",
+        "https://bugzilla.opensuse.org/show_bug.cgi?id=0815",
+        True,
+        browser,
+        browser,
+    )
+    (comment_date, comment_text) = issue.last_comment
+    assert str(comment_date) == "2021-11-15 00:00:00", "creation time read"

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -663,5 +663,19 @@ def test_querying_last_progress_comment():
     args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "progress")
     issue = issue_factory("poo#102440", "https://progress.opensuse.org/issues/102440", args)
     (comment_date, comment_text) = issue.last_comment
-    assert str(comment_date) == "2021-11-15 00:00:00", "creation time read"
-    assert comment_text == "latest progress note", "most recent comment returned"
+    assert str(comment_date) == "2021-11-15 00:00:00", "last update time read"
+    assert comment_text == "latest progress note", "most recent note returned"
+    issue = issue_factory("poo#102441", "https://progress.opensuse.org/issues/102441", args)
+    assert issue.error, "error flag set for non-existing issue"
+    (comment_date, comment_text) = issue.last_comment
+    assert comment_date == None, "no comment date returned for non-existing progress issue"
+    assert comment_text == None, "no comment text returned for non-existing progress issue"
+
+
+def test_querying_last_comment_of_unknown_bugrefs():
+    args = cache_test_args_factory()
+    args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bugzilla")
+    issue = issue_factory("b0o#9315715", "https://bugzilla.opensuse.org/show_bug.cgi?id=9315715", args)
+    (comment_date, comment_text) = issue.last_comment
+    assert comment_date == None, "no comment date returned for unsupported issue"
+    assert comment_text == None, "no comment text returned for unsupported issue"


### PR DESCRIPTION
* Avoid running into an assertion error when trying to find the latest
  comment for an unsupported or erroneous bug reference
* Note that for progress issues the last comment info might *not* be set if
  constructing the issue failed (resulting in an erroneous issue object)
* See https://progress.opensuse.org/issues/102440