### PR TITLE
Create PEP440 version string on dev commits to fix problems running tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from subprocess import check_output, CalledProcessError
+from subprocess import check_output, run, CalledProcessError, DEVNULL
 
 from setuptools import setup
 
@@ -10,11 +10,11 @@ version_py = os.path.join(os.path.dirname(__file__), "version.py")
 
 
 try:
-    # This will not generate PEP440 compliant version strings for any commit
-    # that is not on the tag itself. setuptools/dist will give a warning.
-    # Still, this is good enough for now. A (big) alternative would be
-    # gh:warner/python-versioneer
-    version_git = check_output(["git", "describe", "--tags"]).rstrip().decode("ascii")
+    is_on_tag = run(["git", "describe"], stdout=DEVNULL, stderr=DEVNULL).returncode == 0
+    version_git = check_output(["git", "describe", "--abbrev=0", "--tags"]).rstrip().decode("ascii")
+    if not is_on_tag:
+        dev_revision = check_output(["git", "rev-list", "--count", version_git + "..HEAD"]).rstrip().decode("ascii")
+        version_git += ".dev" + dev_revision
 except (CalledProcessError, OSError):
     try:
         version_git = open(version_py).read().strip().split("=")[-1].replace("'", "").strip()


### PR DESCRIPTION
As of version 20.3 pip requires PEP440 compliant version strings. Not
generating such a version leads to errors when trying to invoke `tox` in
environments which use a newer pip version.

I've been testing this change on a Git commit which is on a tag and one
that is not on a tag. If it is on a tag the tag is used as version (as
before). If it is not on a tag the most recent tag is used and the
development revision appended, e.g. "1.25.0.dev76" (before it would have
been "1.25.0-76-g777610a").

See
* https://github.com/pypa/pip/issues/9188
* https://progress.opensuse.org/issues/102584