### PR TITLE
Avoid assuming wrong character set when reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     url="https://github.com/os-autoinst/openqa_review",
     packages=["openqa_review"],
     py_modules=["version"],
-    long_description=open(os.path.join(os.path.dirname(__file__), "README.md")).read(),
+    long_description=open(os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf-8").read(),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Topic :: Utilities",


### PR DESCRIPTION
This should fix the decoding error we see in OBS builds:

```
[   29s] Traceback (most recent call last):
[   29s]   File "setup.py", line 52, in <module>
[   29s]     long_description=open(os.path.join(os.path.dirname(__file__), "README.md")).read(),
[   29s]   File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
[   29s]     return codecs.ascii_decode(input, self.errors)[0]
[   29s] UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2366: ordinal not in range(128)
```