### PR TITLE
Improve GitHub workflow

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,10 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches: [ '*' ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -27,19 +23,26 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest tox pytest-mock
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      run: python -m pip install tox tox-gh
     - run: env | sort
 
-    - name: test
-      run: |
-        PYTHONVERSION=${{ matrix.python-version }}
-        tox -e py"${PYTHONVERSION/./}"
+    - name: Setup test suite
+      run: tox4 r -vv --notest
+    - name: Run test suite
+      run: tox4 r --skip-pkg-install
+      env:
+        PYTEST_ADDOPTS: "-vv --durations=10"
 
-  coverage:
+  extra:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type:
+        - flake8
+        - black
+        - doctests
+        - cov
 
     steps:
     - uses: actions/checkout@v2
@@ -48,32 +51,13 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest tox pytest-mock
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - run: |
-        tox -e cov
-        ./.tox/cov/bin/coverage html
+      run: python -m pip install tox
+    - run: tox -e ${{ matrix.test-type }}
+    - run: ./.tox/cov/bin/coverage html
+      # Run even if previous step failed but only if we are testing coverage
+      if: ${{ always() && matrix.test-type == 'cov' }}
     - uses: actions/upload-artifact@v2
       with:
         name: coverage
         path: coverage_html/
-
-  style:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest tox pytest-mock
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - run: tox -e doctests
-    - run: tox -e flake8
-    - run: tox -e black
+      if: ${{ always() && matrix.test-type == 'cov' }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# openqa_review_script [![Build Status](https://travis-ci.com/os-autoinst/openqa_review.svg?branch=master)](https://travis-ci.com/os-autoinst/openqa_review) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/699/badge)](https://bestpractices.coreinfrastructure.org/projects/699)
+![test](https://github.com/os-autoinst/openqa_review/actions/workflows/python-package.yaml/badge.svg)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/699/badge)](https://bestpractices.coreinfrastructure.org/projects/699)
+
+
 
 A review helper script for openQA.
 
@@ -105,8 +108,8 @@ tox -e cov
 
 ### Rules for commits
 
-* Every commit is checked by [Travis CI](https://travis-ci.com) as soon as
-  you create a pull request but you *should* run `tox` locally,
+* Every commit is checked by a [GitHub Workflow](https://github.com/os-autoinst/openqa_review/actions)
+  as soon as you create a pull request but you *should* run `tox` locally,
 
 * Make sure to keep the 100% test coverage, e.g. by adding test reference data
   for new scenarios. TDD is advised :-)

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,21 @@ envlist = flake8,black,doctests,py{36,37,38,39},cov
 deps = -rrequirements.txt
 skip_missing_interpreters = true
 
+[gh]
+# splitting the subtests among each environment for speed reasons
+python =
+    3.6  = py36
+    3.7  = py37
+    3.8  = py38
+    3.9  = py39
+    3.10 = py310
+
 [travis]
 # splitting the subtests among each environment for speed reasons
-# TODO doctests fail to find modules on travis
 python =
     3.6: flake8,black,py36
     3.7: py37
-    3.8: py38,cov
+    3.8: py38,cov,doctests
     3.9: py39
 
 [testenv:black]


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/102350

I added a tox plugin like requested from @okurz but also kept the style/coverage tests separate. This way we see immediately which extra test failed without having to dig into the test log.