### PR TITLE
Harmonize they way we query for redmine+bugzilla comments

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -785,7 +785,12 @@ class Issue(object):
 
     @property
     def last_comment(self):
-        """Return datetime object and text of last comment retrieved from an issue."""
+        """Return datetime object and text of all comments retrieved from an issue.
+
+        In case of redmine retrieving comments had been done already as part of
+        the init_redmine call as comments are part of the initial request. For
+        bugzilla we need a separate request.
+        """
         if self.issue_type == "bugzilla" and (self.last_comment_date is None or self.last_comment_text is None):
             res = self.bugzilla_browser.json_rpc_get("/jsonrpc.cgi", "Bug.comments", {"ids": [self.bugid]})
             comments = res["result"]["bugs"][str(self.bugid)]["comments"]

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -655,6 +655,11 @@ Always latest result in this scenario: [latest](%s)
     return ": report [product bug](%s) / [openQA issue](%s)" % (product_bug, test_issue)
 
 
+def _parse_issue_timestamp(timestamp):
+    """Parse the timestamp of a specified redmine issue timestamp field."""
+    return datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+
+
 class Issue(object):
 
     """Issue with extra status info from issue tracker."""
@@ -718,7 +723,7 @@ class Issue(object):
         self.assignee = self.json["assigned_to"]["name"] if "assigned_to" in self.json else "None"
         self.subject = self.json["subject"]
         self.priority = self.json["priority"]["name"]
-        self.last_comment_date = datetime.datetime.strptime(self.json["updated_on"], "%Y-%m-%dT%H:%M:%SZ")
+        self.last_comment_date = _parse_issue_timestamp(self.json["updated_on"])
         self.last_comment_text = ""
         if "journals" in self.json:
             for j in reversed(self.json["journals"]):
@@ -784,7 +789,7 @@ class Issue(object):
         if self.issue_type == "bugzilla" and (self.last_comment_date is None or self.last_comment_text is None):
             res = self.bugzilla_browser.json_rpc_get("/jsonrpc.cgi", "Bug.comments", {"ids": [self.bugid]})
             comments = res["result"]["bugs"][str(self.bugid)]["comments"]
-            self.last_comment_date = datetime.datetime.strptime(comments[-1]["creation_time"], "%Y-%m-%dT%H:%M:%SZ")
+            self.last_comment_date = _parse_issue_timestamp(comments[-1]["creation_time"])
             self.last_comment_text = comments[-1]["text"]
         return (self.last_comment_date, self.last_comment_text)
 

--- a/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B0815%255D%257D%255D
+++ b/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B0815%255D%257D%255D
@@ -1,1 +1,0 @@
-{"id":"https://bugzilla.suse.com/","result":null}

--- a/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B815%255D%257D%255D
+++ b/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.get%26params%3D%255B%257B%2522ids%2522%253A%2B%255B815%255D%257D%255D
@@ -1,0 +1,1 @@
+{"id":"https://bugzilla.suse.com/","result":{"bugs":[{"status":"NEW","summary":"this is a bug","severity":"Normal","priority":"P5 - None"}]}}


### PR DESCRIPTION
Previously redmine would read out comments from the issue journal that
was retrieved along with the initial request. For bugzilla the comments
were requested "on-the-fly" when trying to get the "last comment" from
the issue object. To harmonize that and simplify the code I moved the
bugzilla comment reading into the initialization function so that the
actual requests are conducted more near to each other.

This commit changes the test data accordingly as we now need a valid bug
cache object for bug "815". Previously there was already a seemingly
unused cache file for bug "0815", mind the leading zero.