### PR TITLE
Compute the threshold for sending reminder

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -683,6 +683,7 @@ class Issue(object):
         self.queried = False
         self.last_comment_date = None
         self.last_comment_text = None
+        self.last_comment_delay = 0
         self.issue_type = None
         self.error = False
         self.progress_browser = progress_browser
@@ -734,6 +735,10 @@ class Issue(object):
                     continue
                 self.last_comment_text = j["notes"]
                 break
+            if len(self.json["journals"]) > 1:
+                self.last_comment_delay = (
+                    self.last_comment_date - _parse_issue_timestamp(self.json["journals"][-2]["created_on"])
+                ).days
 
     def _init_bugzilla(self, bugzilla_browser):
         """Initialize data for bugzilla issues."""
@@ -751,6 +756,10 @@ class Issue(object):
         comments = res["result"]["bugs"][str(self.bugid)]["comments"]
         self.last_comment_date = _parse_issue_timestamp(comments[-1]["creation_time"])
         self.last_comment_text = comments[-1]["text"]
+        if len(comments) > 1:
+            self.last_comment_delay = (
+                self.last_comment_date - _parse_issue_timestamp(comments[-2]["creation_time"])
+            ).days
 
     def add_comment(self, comment):
         """Add a comment to an issue with RPC/REST operations."""

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -201,6 +201,8 @@ To prevent further reminder comments one of the following options should be foll
 1. The test scenario is fixed by applying the bug fix to the tested product or the test is adjusted
 2. The openQA job group is moved to "Released" or "EOL" (End-of-Life)
 3. The bugref in the openQA scenario is removed or replaced, e.g. `label:wontfix:boo1234`
+
+Expect the next reminder at the earliest in $time_next days if nothing changes in this ticket.
 """
 )
 
@@ -1588,7 +1590,10 @@ def reminder_comment_on_issue(ie, args):
         f = ie.failures[0]
         if last_comment_text and re.search(re.escape(ie._url(f)), last_comment_text):
             return
-        comment = openqa_issue_comment.substitute({"name": f["name"], "url": ie._url(f)}).strip()
+        next_threshold = args.min_days_unchanged if args.no_exponential_backoff else 2 * threshold
+        comment = openqa_issue_comment.substitute(
+            {"name": f["name"], "url": ie._url(f), "time_next": next_threshold}
+        ).strip()
         issue.add_comment(comment)
 
 

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -1401,6 +1401,12 @@ def parse_args():
         help="""The minimum period of days that need to be passed since the last comment for the bug to be reminded upon.""",
     )
     reminder_comments.add_argument(
+        "--no-exponential-backoff",
+        action="store_true",
+        default=False,
+        help="""Disable exponential backoff algorithm for reminders.""",
+    )
+    reminder_comments.add_argument(
         "--no-reminder-on",
         dest="ignore_pattern",
         type=re.compile,

--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -1579,7 +1579,12 @@ def reminder_comment_on_issue(ie, args):
         if reason and args.ignore_pattern and re.search(args.ignore_pattern, reason):
             return
     (last_comment_date, last_comment_text) = issue.last_comment
-    if (datetime.datetime.utcnow() - last_comment_date).days >= args.min_days_unchanged:
+    threshold = (
+        args.min_days_unchanged
+        if args.no_exponential_backoff
+        else max(2 * issue.last_comment_delay, args.min_days_unchanged)
+    )
+    if (datetime.datetime.utcnow() - last_comment_date).days >= threshold:
         f = ie.failures[0]
         if last_comment_text and re.search(re.escape(ie._url(f)), last_comment_text):
             return

--- a/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.comments%26params%3D%255B%257B%2522ids%2522%253A%2B%255B815%255D%257D%255D
+++ b/tests/bugzilla/:jsonrpc.cgi%3Fmethod%3DBug.comments%26params%3D%255B%257B%2522ids%2522%253A%2B%255B815%255D%257D%255D
@@ -1,1 +1,1 @@
-{"result":{"bugs":{"815":{"comments":[{"text":"some bugzilla comment"},{"creation_time":"2021-11-15T00:00:00Z","text":"most recent bugzilla comment"}]}}}}
+{"result":{"bugs":{"815":{"comments":[{"creation_time":"2021-11-01T00:00:00Z","text":"some bugzilla comment"},{"creation_time":"2021-11-15T00:00:00Z","text":"most recent bugzilla comment"}]}}}}

--- a/tests/progress/https%3A::progress.opensuse.org:issues:102440.json%3Finclude%3Djournals
+++ b/tests/progress/https%3A::progress.opensuse.org:issues:102440.json%3Finclude%3Djournals
@@ -1,1 +1,1 @@
-{"issue":{"status":{"name":"foo"},"subject":"bar","priority":{"name":"urgent"},"updated_on":"2021-11-15T00:00:00Z","journals":[{"notes":"first progress note"},{"notes":"latest progress note"}]}}
+{"issue":{"status":{"name":"foo"},"subject":"bar","priority":{"name":"urgent"},"updated_on":"2021-11-15T00:00:00Z","journals":[{"notes":"first progress note","created_on":"2021-11-07T16:38:33Z"},{"notes":"latest progress note","created_on":"2021-11-15T00:00:00Z"}]}}

--- a/tests/progress/https%3A::progress.opensuse.org:issues:102442.json%3Finclude%3Djournals
+++ b/tests/progress/https%3A::progress.opensuse.org:issues:102442.json%3Finclude%3Djournals
@@ -1,0 +1,1 @@
+{"issue":{"status":{"name":"foo"},"subject":"bar","priority":{"name":"urgent"},"updated_on":"2021-11-15T00:00:00Z","journals":[{"notes":"only one progress note","created_on":"2021-11-07T16:38:33Z"}]}}

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -673,6 +673,7 @@ def test_querying_last_bugzilla_comment():
     (comment_date, comment_text) = issue.last_comment
     assert str(comment_date) == "2021-11-15 00:00:00", "creation time read"
     assert comment_text == "most recent bugzilla comment", "most recent comment returned"
+    assert issue.last_comment_delay == 14, "last comment was added after 14 days"
 
 
 def test_querying_last_progress_comment():
@@ -682,6 +683,7 @@ def test_querying_last_progress_comment():
     (comment_date, comment_text) = issue.last_comment
     assert str(comment_date) == "2021-11-15 00:00:00", "last update time read"
     assert comment_text == "latest progress note", "most recent note returned"
+    assert issue.last_comment_delay == 7, "last comment was added after 7 days"
     issue = issue_factory("poo#102441", "https://progress.opensuse.org/issues/102441", args)
     assert issue.error, "error flag set for non-existing issue"
     (comment_date, comment_text) = issue.last_comment

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -55,6 +55,8 @@ def args_factory():
     args.report_links = False
     args.skip_passed = False
     args.todo_only = False
+    args.min_days_unchanged = openqa_review.MIN_DAYS_UNCHANGED
+    args.ignore_pattern = openqa_review.NO_REMINDER_REGEX
     return args
 
 
@@ -533,7 +535,7 @@ def test_reminder_comments_on_referenced_bugs_are_posted():
     p, pr = list(report.report.items())[0]
     report.report[p + 237] = pr
 
-    openqa_review.reminder_comment_on_issues(report)
+    openqa_review.reminder_comment_on_issues(report, args)
     args.dry_run = False
 
 
@@ -546,7 +548,7 @@ def test_reminder_comments_on_referenced_bugs_are_not_duplicated(browser_mock):
     args.include_softfails = True
     args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "without_duplicates")
     report = openqa_review.generate_report(args)
-    openqa_review.reminder_comment_on_issues(report)
+    openqa_review.reminder_comment_on_issues(report, args)
     args.dry_run = False
     browser_mock.assert_not_called()
 
@@ -561,10 +563,11 @@ def test_reminder_comments_are_ignored_on_no_reminder(browser_mock):
     args.query_issue_status = True
     report = openqa_review.generate_report(args)
     # there should be no comment with default WONTFIX|NO_REMINDER softfail pattern
-    openqa_review.reminder_comment_on_issues(report)
+    openqa_review.reminder_comment_on_issues(report, args)
     browser_mock.assert_not_called()
     # without the pattern, there shall be one reminder
-    openqa_review.reminder_comment_on_issues(report, openqa_review.MIN_DAYS_UNCHANGED, None)
+    args.ignore_pattern = None
+    openqa_review.reminder_comment_on_issues(report, args)
     browser_mock.assert_called_once()
     args.dry_run = False
 

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -688,6 +688,8 @@ def test_querying_last_progress_comment():
     assert str(comment_date) == "2021-11-15 00:00:00", "last update time read"
     assert comment_text == "latest progress note", "most recent note returned"
     assert issue.last_comment_delay == 7, "last comment was added after 7 days"
+    issue = issue_factory("poo#102442", "https://progress.opensuse.org/issues/102442", args)
+    assert issue.last_comment_delay == 0, "no delay for only one comment"
     issue = issue_factory("poo#102441", "https://progress.opensuse.org/issues/102441", args)
     assert issue.error, "error flag set for non-existing issue"
     (comment_date, comment_text) = issue.last_comment

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -57,6 +57,7 @@ def args_factory():
     args.todo_only = False
     args.min_days_unchanged = openqa_review.MIN_DAYS_UNCHANGED
     args.ignore_pattern = openqa_review.NO_REMINDER_REGEX
+    args.no_exponential_backoff = False
     return args
 
 


### PR DESCRIPTION
The threshold computation defaults to exponential backoff taking into
account the delay between the last and second to last comment. The time
will be never less than MIN_DAYS_UNCHANGED days.

Include expected time until next reminder message.

Related ticket: https://progress.opensuse.org/issues/106907