### PR TITLE
Run CI for Python 3.6 on Ubuntu 20.04

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -4,8 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -15,6 +14,12 @@ jobs:
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
+        - '3.12.0-alpha - 3.12.0'
+        include:
+          - os: "ubuntu-latest"
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = black --check --diff --fast .
 
 [testenv:flake8]
 deps =
-    flake8
+    flake8<6.0.0  # TODO remove pinned version once https://github.com/zheller/flake8-quotes/pull/111 is merged.
     flake8-black
     flake8-docstrings
     flake8-quotes

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
 
 [testenv:black]
 deps =


### PR DESCRIPTION
The now latest Ubuntu no longer ships with 3.6.