### PR TITLE
Inject Bugzilla API token into params

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -149,6 +149,8 @@ system = bugzilla
 # local keyring if found
 #username = user
 #password = secret
+# newer Bugzilla versions use an API key instead of username and password
+#api_key = token
 base_url = https://apibugzilla.suse.com
 report_url = https://bugzilla.suse.com
 
@@ -349,13 +351,18 @@ def progress_browser_factory(args):
 
 
 def bugzilla_browser_factory(args):
+    auth = ()
+    # We need either an API key or login & password
+    if not config.has_option("product_issues", "api_key"):
+        auth = (
+            config.get("product_issues", "username", fallback=None),
+            config.get("product_issues", "password", fallback=None),
+        )
     return Browser(
         args,
         config.get("product_issues", "base_url"),
-        auth=(
-            config.get("product_issues", "username"),
-            config.get("product_issues", "password"),
-        ),
+        auth,
+        api_key=config.get("product_issues", "api_key", fallback=None),
     )
 
 

--- a/tests/test_openqa_review.py
+++ b/tests/test_openqa_review.py
@@ -699,6 +699,24 @@ def test_get_bugzilla_issue():
         assert e.code == 300
 
 
+def test_bugzilla_with_api_key():
+    openqa_review.config.remove_option("product_issues", "username")
+    openqa_review.config.remove_option("product_issues", "password")
+    openqa_review.config.set("product_issues", "api_key", "token")
+    args = cache_test_args_factory()
+    args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bugzilla")
+    browser = openqa_review.bugzilla_browser_factory(args)
+    assert browser.api_key, "API key used"
+    issue = openqa_review.Issue(
+        "boo#0815",
+        "https://bugzilla.opensuse.org/show_bug.cgi?id=0815",
+        query_issue_status=True,
+        bugzilla_browser=browser,
+        progress_browser=browser,
+    )
+    assert issue.bugid == 815, "Bugzilla issue parsed"
+
+
 def test_querying_last_bugzilla_comment():
     args = cache_test_args_factory()
     args.load_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bugzilla")


### PR DESCRIPTION
Unlike the login used so far, an API key needs to be included with the params passed to the API. Doing both at once should retain compatibility between Bugzilla versions.

See: https://progress.opensuse.org/issues/120525