### PR TITLE
Add commandline usage from git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ pip3 install -r requirements.txt
 pip3 install .
 ```
 
+To call the script from the git clone, you have to use this form:
+
+```
+python3 -m openqa_review.openqa_review
+```
+
 or if you are using openSUSE distribution, it is recommended to use `zypper`,
 e.g.:
 


### PR DESCRIPTION
Just calling the script like this doesn't work, at least not with python 3.11:

    % python openqa_review/openqa_review.py
    Traceback (most recent call last):
      File "path/to/openqa_review/openqa_review/openqa_review.py", line 110, in <module>
        from .browser import Browser, DownloadError, BugNotFoundError, add_load_save_args  # isort:skip
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ImportError: attempted relative import with no known parent package