### PR TITLE
WIP: Simplify how builds are sorted

### DIFF
--- a/openqa_review/openqa_review.py
+++ b/openqa_review/openqa_review.py
@@ -109,7 +109,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from .browser import Browser, DownloadError, BugNotFoundError, add_load_save_args  # isort:skip
 
-
 # treat humanfriendly as optional dependency
 humanfriendly_available = False
 try:
@@ -439,18 +438,17 @@ def find_builds(builds, running_threshold=0):
     def non_empty(r):
         return r["total"] != 0 and r["total"] > r["skipped"] and not ("build" in r.keys() and r["build"] is None)
 
-    builds = {build: result for build, result in builds.items() if non_empty(result)}
-    finished = {
-        build: result
-        for build, result in builds.items()
-        if not result["unfinished"] or (100 * float(result["unfinished"]) / result["total"]) <= threshold
-    }
+    finished = [
+        build
+        for build in builds
+        if non_empty(build)
+        and (not build["unfinished"] or (100 * float(build["unfinished"]) / build["total"]) <= threshold)
+    ]
 
-    log.debug("Found the following finished non-empty builds: %s" % ", ".join(finished.keys()))
+    log.debug("Found the following finished non-empty builds: %s" % ", ".join([build["key"] for build in finished]))
     if len(finished) < 2:
         raise NotEnoughBuildsError("not enough finished builds found")
-    assert len(finished.keys()) >= 2
-    return finished.keys()
+    return finished
 
 
 def find_last_reviewed_build(comments):
@@ -468,18 +466,6 @@ def find_last_reviewed_build(comments):
     return last_reviewed
 
 
-def mysort(x):
-    """Sort strings like build numbers with dashes and/or dots, e.g. 12-SP5-0456."""
-    s = []
-    for i in re.split("[-.]", x):
-        try:
-            i = "%020d" % int(i)
-        except ValueError:
-            pass
-        s.append(i)
-    return s
-
-
 def get_build_urls_to_compare(browser, job_group_url, builds="", against_reviewed=None, running_threshold=0):
     """
     From the job group page get URLs for the builds to compare.
@@ -493,36 +479,34 @@ def get_build_urls_to_compare(browser, job_group_url, builds="", against_reviewe
       'finished' anyway
     """
     job_group = browser.get_json("%s.json" % job_group_url)
-
-    def get_group_result():
-        try:
-            results_list = job_group["build_results"]
-            return {i["key"]: i for i in results_list}
-        except KeyError:
-            log.debug("Reverting to old openQA behaviour before openQA#9b50b22")
-            return job_group["result"]
+    build_results = job_group["build_results"]
 
     def build_url(build):
-        r = get_group_result()
-        b = r.get(build, next(iter(r.values())))
-        build = b.get("build", build)
+        if isinstance(build, str):
+            for b in build_results:
+                if b.get("key" "") == build or b.get("build", "") == build:
+                    build = b
+                    break
+        if isinstance(build, str):
+            build = build_results[0]
+
+
         # openQA introduced multi-distri support for the job groups with openQA#037ffd33
         distri_str = (
-            "distri=%s" % b["distri"]
-            if "distri" in b.keys()
-            else "distri=" + "&distri=".join(sorted(b["distris"].keys()))
+            "distri=%s" % build["distri"]
+            if "distri" in build.keys()
+            else "distri=" + "&distri=".join(sorted(build["distris"].keys()))
         )
         return "/tests/overview?%s&version=%s&build=%s&groupid=%i" % (
             distri_str,
-            quote(b["version"]),
-            quote(build),
+            quote(build["version"]),
+            quote(build.get("build", build["key"])),
             job_group["group"]["id"],
         )
 
-    finished_builds = find_builds(get_group_result(), running_threshold)
-    # find last finished and previous one
-
-    builds_to_compare = sorted(finished_builds, key=mysort, reverse=True)[0:2]
+    finished_builds = find_builds(build_results, running_threshold)
+    # use last finished build and previous finished build
+    builds_to_compare = [finished_builds[0], finished_builds[1]]
 
     if builds:
         # User has to be careful here. A page for non-existent builds is always
@@ -543,7 +527,7 @@ def get_build_urls_to_compare(browser, job_group_url, builds="", against_reviewe
 
     log.debug("Comparing build %s against %s" % (builds_to_compare[0], builds_to_compare[1]))
     current_url, previous_url = map(build_url, builds_to_compare)
-    log.debug("Found two build URLS, current: %s previous: %s" % (current_url, previous_url))
+    log.debug("Found two build URLs, current: %s previous: %s" % (current_url, previous_url))
     return current_url, previous_url
 
 

--- a/tests/differing_tests/https%3A::openqa.opensuse.org:group_overview:25.json
+++ b/tests/differing_tests/https%3A::openqa.opensuse.org:group_overview:25.json
@@ -4,8 +4,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 25, "name": "openSUSE Tumbleweed 1.Gnome"},
-	"result": {
-		"0389": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -18,9 +18,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "0389"
 		},
-		"0405": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -33,7 +34,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 4,
-			"total": 92
+			"total": 92,
+			"key": "0405"
 		}
-	}
+	]
 }

--- a/tests/https%3A::openqa.opensuse.org:group_overview:25.json
+++ b/tests/https%3A::openqa.opensuse.org:group_overview:25.json
@@ -8,8 +8,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 25, "name": "openSUSE Tumbleweed Gnome"},
-	"result": {
-		"0299": {
+	"build_results": [
+		{
 			"distris": {"opensuse": 1, "kubic": 1},
 			"version": "42.1",
 			"reviewed": "",
@@ -22,9 +22,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0299"
 		},
-		"0300": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -37,9 +38,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0300"
 		},
-		"0304": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -52,9 +54,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "0304"
 		},
-		"0305": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -67,9 +70,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 46
+			"total": 46,
+			"key": "0305"
 		},
-		"0306": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -82,9 +86,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0306"
 		},
-		"0307": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -97,9 +102,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 77
+			"total": 77,
+			"key": "0307"
 		},
-		"0308": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -112,9 +118,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "0308"
 		},
-		"0311": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -127,9 +134,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "0311"
 		},
-		"0313": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -142,9 +150,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "0313"
 		},
-		"0318": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -157,7 +166,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 33,
-			"total": 91
+			"total": 91,
+			"key": "0318"
 		}
-	}
+	]
 }

--- a/tests/https%3A::openqa.opensuse.org:group_overview:26.json
+++ b/tests/https%3A::openqa.opensuse.org:group_overview:26.json
@@ -8,8 +8,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 26, "name": "openSUSE Leap"},
-	"result": {
-		"62.1": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "15",
 			"reviewed": "",
@@ -23,9 +23,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "62.1"
 		},
-		"162.2": {
+		{
 			"distri": "opensuse",
 			"version": "15",
 			"reviewed": "",
@@ -39,9 +40,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "162.2"
 		},
-		"170.1": {
+		{
 			"distri": "opensuse",
 			"version": "15",
 			"reviewed": "",
@@ -55,9 +57,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "170.1"
 		},
-		"170.4": {
+		{
 			"distri": "opensuse",
 			"version": "15",
 			"reviewed": "",
@@ -71,7 +74,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 33,
-			"total": 91
+			"total": 91,
+			"key": "170.4"
 		}
-	}
+	]
 }

--- a/tests/https%3A::openqa.opensuse.org:group_overview:4.json
+++ b/tests/https%3A::openqa.opensuse.org:group_overview:4.json
@@ -8,8 +8,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 4, "name": "openSUSE Tumbleweed PowerPC"},
-	"result": {
-		"20160905": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -22,9 +22,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "20160905"
 		},
-		"20160907": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -37,9 +38,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "20160907"
 		},
-		"20160908": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -52,9 +54,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "20160908"
 		},
-		"20160909": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -67,9 +70,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 46
+			"total": 46,
+			"key": "20160909"
 		},
-		"20160911": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -82,9 +86,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "20160911"
 		},
-		"20160912": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -97,9 +102,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 77
+			"total": 77,
+			"key": "20160912"
 		},
-		"20160913": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -112,9 +118,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "20160913"
 		},
-		"20160914": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -127,9 +134,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "20160914"
 		},
-		"20160916": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -142,9 +150,10 @@
 			"skipped": 0,
 			"softfailed": 7,
 			"unfinished": 0,
-			"total": 18
+			"total": 18,
+			"key": "20160916"
 		},
-		"20160917": {
+		{
 			"distri": "opensuse",
 			"version": "Tumbleweed",
 			"reviewed": "",
@@ -157,7 +166,8 @@
 			"skipped": 0,
 			"softfailed": 7,
 			"unfinished": 0,
-			"total": 18
+			"total": 18,
+			"key": "20160917"
 		}
-	}
+	]
 }

--- a/tests/live/https%3A::openqa.opensuse.org:group_overview:27.json
+++ b/tests/live/https%3A::openqa.opensuse.org:group_overview:27.json
@@ -7,8 +7,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 27, "name": "openSUSE Tumbleweed PowerPC"},
-	"result": {
-		"0103@0337": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -21,9 +21,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0103@0337"
 		},
-		"0103@0339": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -36,9 +37,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0103@0339"
 		},
-		"0103@0340": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -51,9 +53,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "0103@0340"
 		},
-		"0103@0343": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -66,9 +69,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 46
+			"total": 46,
+			"key": "0103@0343"
 		},
-		"0103@0344": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -81,9 +85,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0103@0344"
 		},
-		"0104@0347": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -96,9 +101,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 77
+			"total": 77,
+			"key": "0104@0347"
 		},
-		"0104@0349": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -111,9 +117,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "0104@0349"
 		},
-		"0104@0350": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -126,9 +133,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "0104@0350"
 		},
-		"0104@0351": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -141,9 +149,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 14
+			"total": 14,
+			"key": "0104@0351"
 		},
-		"0104@0352": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -156,9 +165,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 0
+			"total": 0,
+			"key": "0104@0352"
 		},
-		"0104@0353": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -171,7 +181,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 1,
-			"total": 14
+			"total": 14,
+			"key": "0104@0353"
 		}
-	}
+	]
 }

--- a/tests/live_no_review/https%3A::openqa.opensuse.org:group_overview:27.json
+++ b/tests/live_no_review/https%3A::openqa.opensuse.org:group_overview:27.json
@@ -4,8 +4,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 27, "name": "openSUSE Tumbleweed 3. Live"},
-	"result": {
-		"0103@0337": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -18,9 +18,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0103@0337"
 		},
-		"0103@0339": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -33,9 +34,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0103@0339"
 		},
-		"0103@0340": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -48,9 +50,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "0103@0340"
 		},
-		"0103@0343": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -63,9 +66,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 46
+			"total": 46,
+			"key": "0103@0343"
 		},
-		"0103@0344": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -78,9 +82,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0103@0344"
 		},
-		"0104@0347": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -93,9 +98,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 77
+			"total": 77,
+			"key": "0104@0347"
 		},
-		"0104@0349": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -108,9 +114,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "0104@0349"
 		},
-		"0104@0350": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -123,9 +130,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "0104@0350"
 		},
-		"0104@0351": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -138,9 +146,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 14
+			"total": 14,
+			"key": "0104@0351"
 		},
-		"0104@0352": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -153,9 +162,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 0
+			"total": 0,
+			"key": "0104@0352"
 		},
-		"0104@0353": {
+		{
 			"distri": "opensuse",
 			"version": "42.1-Live",
 			"reviewed": "",
@@ -168,7 +178,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 1,
-			"total": 14
+			"total": 14,
+			"key": "0104@0353"
 		}
-	}
+	]
 }

--- a/tests/only_old_invalid_builds/https%3A::openqa.opensuse.org:group_overview:28.json
+++ b/tests/only_old_invalid_builds/https%3A::openqa.opensuse.org:group_overview:28.json
@@ -1,1 +1,66 @@
-{"comments": [], "description": "", "max_jobs": 8, "result": {"76.1": {"reviewed": "", "distri": "opensuse", "failed": 0, "passed": 0, "softfailed": 0, "reviewed_all_passed": "", "escaped_id": "76_1", "oldest": "2016-11-04T13:31:12", "version": "42.1", "skipped": 8, "total": 8, "unfinished": 0, "labeled": 0}, "5.176": {"reviewed": "", "distri": "opensuse", "failed": 0, "passed": 0, "softfailed": 0, "reviewed_all_passed": "", "escaped_id": "5_176", "oldest": "2016-11-04T13:31:57", "version": "42.1", "skipped": 2, "total": 2, "unfinished": 0, "labeled": 0}, "76.2": {"reviewed": "", "distri": "opensuse", "failed": 0, "passed": 0, "softfailed": 0, "reviewed_all_passed": "", "escaped_id": "76_2", "oldest": "2016-11-04T13:31:10", "version": "42.1", "skipped": 8, "total": 8, "unfinished": 0, "labeled": 0}, "78.1": {"reviewed": "", "distri": "opensuse", "failed": 0, "passed": 0, "softfailed": 0, "reviewed_all_passed": "", "escaped_id": "78_1", "oldest": "2016-11-04T13:31:13", "version": "42.1", "skipped": 8, "total": 8, "unfinished": 0, "labeled": 0}}, "group": {"name": "Staging: openSUSE Tumbleweed ", "id": 28}, "pinned_comments": []}
+{"comments": [], "description": "", "max_jobs": 8, "build_results": [
+  {
+    "reviewed": "",
+    "distri": "opensuse",
+    "failed": 0,
+    "passed": 0,
+    "softfailed": 0,
+    "reviewed_all_passed": "",
+    "escaped_id": "76_1",
+    "oldest": "2016-11-04T13:31:12",
+    "version": "42.1",
+    "skipped": 8,
+    "total": 8,
+    "unfinished": 0,
+    "labeled": 0,
+    "key": "76.1"
+  },
+  {
+    "reviewed": "",
+    "distri": "opensuse",
+    "failed": 0,
+    "passed": 0,
+    "softfailed": 0,
+    "reviewed_all_passed": "",
+    "escaped_id": "5_176",
+    "oldest": "2016-11-04T13:31:57",
+    "version": "42.1",
+    "skipped": 2,
+    "total": 2,
+    "unfinished": 0,
+    "labeled": 0,
+    "key": "5.176"
+  },
+  {
+    "reviewed": "",
+    "distri": "opensuse",
+    "failed": 0,
+    "passed": 0,
+    "softfailed": 0,
+    "reviewed_all_passed": "",
+    "escaped_id": "76_2",
+    "oldest": "2016-11-04T13:31:10",
+    "version": "42.1",
+    "skipped": 8,
+    "total": 8,
+    "unfinished": 0,
+    "labeled": 0,
+    "key": "76.2"
+  },
+  {
+    "reviewed": "",
+    "distri": "opensuse",
+    "failed": 0,
+    "passed": 0,
+    "softfailed": 0,
+    "reviewed_all_passed": "",
+    "escaped_id": "78_1",
+    "oldest": "2016-11-04T13:31:13",
+    "version": "42.1",
+    "skipped": 8,
+    "total": 8,
+    "unfinished": 0,
+    "labeled": 0,
+    "key": "78.1"
+  }
+], "group": {"name": "Staging: openSUSE Tumbleweed ", "id": 28}, "pinned_comments": []}

--- a/tests/single_job_group/https%3A::openqa.opensuse.org:group_overview:22.json
+++ b/tests/single_job_group/https%3A::openqa.opensuse.org:group_overview:22.json
@@ -7,8 +7,9 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 22, "name": "openSUSE Leap 42.2 AArch64"},
-	"result": {
-		"1.64": {
+	"build_results": [
+		{
+			"key": "1.64",
 			"distri": "opensuse",
 			"version": "12",
 			"reviewed": "",
@@ -23,5 +24,5 @@
 			"unfinished": 0,
 			"total": 2
 		}
-	}
+	]
 }

--- a/tests/single_job_group/https%3A::openqa.opensuse.org:group_overview:25.json
+++ b/tests/single_job_group/https%3A::openqa.opensuse.org:group_overview:25.json
@@ -7,8 +7,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 25, "name": "openSUSE Tumbleweed Gnome"},
-	"result": {
-		"0299": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -21,9 +21,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0299"
 		},
-		"0300": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -36,9 +37,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0300"
 		},
-		"0304": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -51,9 +53,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "0304"
 		},
-		"0305": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -66,9 +69,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 46
+			"total": 46,
+			"key": "0305"
 		},
-		"0306": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -81,9 +85,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "0306"
 		},
-		"0307": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -96,9 +101,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 77
+			"total": 77,
+			"key": "0307"
 		},
-		"0308": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -111,9 +117,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "0308"
 		},
-		"0311": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -126,9 +133,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "0311"
 		},
-		"0313": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -141,9 +149,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "0313"
 		},
-		"0318": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -156,7 +165,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 33,
-			"total": 91
+			"total": 91,
+			"key": "0318"
 		}
-	}
+	]
 }

--- a/tests/tags_labels/https%3A::openqa.opensuse.org:group_overview:25.json
+++ b/tests/tags_labels/https%3A::openqa.opensuse.org:group_overview:25.json
@@ -4,8 +4,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 25, "name": "openSUSE Tumbleweed 1.Gnome ✓"},
-	"result": {
-		"1500": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -18,9 +18,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "1500"
 		},
-		"1501": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -33,9 +34,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "1501"
 		},
-		"1502": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -48,9 +50,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "1502"
 		},
-		"1503": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -63,9 +66,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 46
+			"total": 46,
+			"key": "1503"
 		},
-		"1505": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -78,9 +82,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "1505"
 		},
-		"1506": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -93,9 +98,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 77
+			"total": 77,
+			"key": "1506"
 		},
-		"1507": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -108,9 +114,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "1507"
 		},
-		"1508": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -123,9 +130,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "1508"
 		},
-		"1509": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -138,9 +146,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "1509"
 		},
-		"1510": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -153,7 +162,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 33,
-			"total": 91
+			"total": 91,
+			"key": "1510"
 		}
-	}
+	]
 }

--- a/tests/tags_labels/report_link_new_issue/https%3A::openqa.opensuse.org:group_overview:25.json
+++ b/tests/tags_labels/report_link_new_issue/https%3A::openqa.opensuse.org:group_overview:25.json
@@ -4,8 +4,8 @@
 	"description": "",
 	"max_jobs": 91,
 	"group": {"id": 25, "name": "openSUSE Tumbleweed 1.Gnome ✓"},
-	"result": {
-		"2130": {
+	"build_results": [
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -18,9 +18,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "2130"
 		},
-		"2131": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -33,9 +34,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "2131"
 		},
-		"2132": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -48,9 +50,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 91
+			"total": 91,
+			"key": "2132"
 		},
-		"2133": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -63,9 +66,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 46
+			"total": 46,
+			"key": "2133"
 		},
-		"2134": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -78,9 +82,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 90
+			"total": 90,
+			"key": "2134"
 		},
-		"2136": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -93,9 +98,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 77
+			"total": 77,
+			"key": "2136"
 		},
-		"2137": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -108,9 +114,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "2137"
 		},
-		"2138": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -123,9 +130,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 59
+			"total": 59,
+			"key": "2138"
 		},
-		"2139": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -138,9 +146,10 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 0,
-			"total": 47
+			"total": 47,
+			"key": "2139"
 		},
-		"2140": {
+		{
 			"distri": "opensuse",
 			"version": "42.1",
 			"reviewed": "",
@@ -153,7 +162,8 @@
 			"skipped": 0,
 			"softfailed": 0,
 			"unfinished": 33,
-			"total": 91
+			"total": 91,
+			"key": "2140"
 		}
-	}
+	]
 }


### PR DESCRIPTION
* Use the build order from openQA
* Drop own sorting algorithm
* Break compatibility with very old versions of openQA that returned build results as JSON object (and not array)
* Keep the behavior mainly as-is considering the sorting algorithm of the review script was quite close to what openQA does in most cases so this is really mainly a simplification and won't change the behavior mentioned on https://progress.opensuse.org/issues/184132#note-6