### PR TITLE
Remove flake pinned version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands = black --check --diff --fast .
 
 [testenv:flake8]
 deps =
-    flake8<6.0.0  # TODO remove pinned version once https://github.com/zheller/flake8-quotes/pull/111 is merged.
+    flake8
     flake8-black
     flake8-docstrings
     flake8-quotes


### PR DESCRIPTION
https://github.com/zheller/flake8-quotes/pull/111 is merged back in 2022

related poo: https://progress.opensuse.org/issues/184507